### PR TITLE
Validate mtime in MountOptions.load, drop epoch fallback

### DIFF
--- a/TestFSExtension/MountOptions.swift
+++ b/TestFSExtension/MountOptions.swift
@@ -175,10 +175,7 @@ func parseSize(_ raw: String) -> Int? {
 }
 
 extension MountOptions {
-    /// Parse a `mtime` string, accepting date-only (`YYYY-MM-DD`) or
-    /// full ISO 8601 (`YYYY-MM-DDTHH:mm:ssZ`). Date-only is
-    /// midnight UTC. Single source of truth used by both the host's
-    /// GUI picker and the extension.
+    /// Accepts date-only (`YYYY-MM-DD`, midnight UTC) or full ISO 8601.
     static func parseMtime(_ raw: String) -> Date? {
         let dateOnly = ISO8601DateFormatter()
         dateOnly.formatOptions = [.withFullDate]
@@ -188,7 +185,6 @@ extension MountOptions {
         return dateTime.date(from: raw)
     }
 
-    /// ISO 8601 string `parseMtime` round-trips.
     static func formatMtime(_ date: Date) -> String {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
@@ -390,6 +386,9 @@ extension MountOptions {
         }
         guard options.iopLimit >= 0 else {
             throw LoadError.invalidIopLimit(options.iopLimit)
+        }
+        guard parseMtime(options.mtime) != nil else {
+            throw LoadError.invalidMtime(options.mtime)
         }
         return options
     }

--- a/TestFSExtension/MountOptions.swift
+++ b/TestFSExtension/MountOptions.swift
@@ -307,6 +307,7 @@ extension MountOptions {
         case invalidPreGeneratedBlocks(Int)
         case invalidRateLimit(Double)
         case invalidIopLimit(Int)
+        case invalidMtime(String)
         case malformed(underlying: Error)
 
         var errorDescription: String? {
@@ -323,6 +324,8 @@ extension MountOptions {
                 return "rate_limit must be >= 0, got \(value)"
             case .invalidIopLimit(let value):
                 return "iop_limit must be >= 0, got \(value)"
+            case .invalidMtime(let value):
+                return "mtime must be 'YYYY-MM-DD' or full ISO 8601, got '\(value)'"
             case .malformed(let err):
                 return "malformed sidecar JSON: \(err.localizedDescription)"
             }

--- a/TestFSExtension/TestFSVolume.swift
+++ b/TestFSExtension/TestFSVolume.swift
@@ -44,9 +44,9 @@ final class TestFSVolume: FSVolume {
 
         let uid = options.uid ?? getuid()
         let gid = options.gid ?? getgid()
-        // Safe to force-unwrap: MountOptions.load rejects unparseable
-        // mtime; tests constructing MountOptions directly use the
-        // default, which is a valid date.
+        // Safe: load() rejects unparseable mtime, and the default
+        // ("2017-10-17") parses. Test-constructed options bypassing
+        // load() must use a parseable mtime.
         let mtimeDate = MountOptions.parseMtime(options.mtime)!
         let mtime = timespec(tv_sec: Int(mtimeDate.timeIntervalSince1970), tv_nsec: 0)
         let dirMode = UInt32(S_IFDIR | 0o555)

--- a/TestFSExtension/TestFSVolume.swift
+++ b/TestFSExtension/TestFSVolume.swift
@@ -44,7 +44,10 @@ final class TestFSVolume: FSVolume {
 
         let uid = options.uid ?? getuid()
         let gid = options.gid ?? getgid()
-        let mtimeDate = MountOptions.parseMtime(options.mtime) ?? Date(timeIntervalSince1970: 0)
+        // Safe to force-unwrap: MountOptions.load rejects unparseable
+        // mtime; tests constructing MountOptions directly use the
+        // default, which is a valid date.
+        let mtimeDate = MountOptions.parseMtime(options.mtime)!
         let mtime = timespec(tv_sec: Int(mtimeDate.timeIntervalSince1970), tv_nsec: 0)
         let dirMode = UInt32(S_IFDIR | 0o555)
         let fileMode = UInt32(S_IFREG | 0o444)

--- a/Tests/TestFSCoreTests/MountOptionsTests.swift
+++ b/Tests/TestFSCoreTests/MountOptionsTests.swift
@@ -193,7 +193,7 @@ final class MountOptionsTests: XCTestCase {
 
     func testRejectsInvalidMtime() {
         // A bad mtime would otherwise mount silently with epoch
-        // timestamps for every file (issue #24).
+        // timestamps for every file.
         let json = Data(#"{"config":"/t","mtime":"not-a-date"}"#.utf8)
         XCTAssertThrowsError(try MountOptions.load(from: json)) { error in
             guard let err = error as? MountOptions.LoadError,

--- a/Tests/TestFSCoreTests/MountOptionsTests.swift
+++ b/Tests/TestFSCoreTests/MountOptionsTests.swift
@@ -191,6 +191,19 @@ final class MountOptionsTests: XCTestCase {
         }
     }
 
+    func testRejectsInvalidMtime() {
+        // A bad mtime would otherwise mount silently with epoch
+        // timestamps for every file (issue #24).
+        let json = Data(#"{"config":"/t","mtime":"not-a-date"}"#.utf8)
+        XCTAssertThrowsError(try MountOptions.load(from: json)) { error in
+            guard let err = error as? MountOptions.LoadError,
+                case .invalidMtime = err
+            else {
+                return XCTFail("expected .invalidMtime, got \(error)")
+            }
+        }
+    }
+
     func testRejectsUnknownUnicodeNormalization() {
         let json = Data(#"{"config":"/t","unicode_normalization":"NFZ"}"#.utf8)
         XCTAssertThrowsError(try MountOptions.load(from: json)) { error in


### PR DESCRIPTION
Fixes #24.

`MountOptions.load` now rejects sidecars whose `mtime` can't be parsed by `ISO8601DateFormatter` (date-only `YYYY-MM-DD` or full ISO 8601). The volume init can now force-unwrap `parseMtime` instead of silently falling back to `1970-01-01`.

## Commits

- 8f23428 — red regression test (`MountOptions.load` accepting `\"not-a-date\"`)
- 2545aad — fix: add `LoadError.invalidMtime`, validate in `load()`, drop epoch fallback in `TestFSVolume.init`
- 7c2685e — simplify pass: trim test comment + tighten force-unwrap rationale

## Verification

- \`swift test\`: 96 tests pass
- \`swiftlint --strict\`: 0 violations
- \`xcodebuild ... build\`: succeeds