### PR TITLE
unmount.sh: detach by mount-backed device, sweep dummies/ orphans

### DIFF
--- a/scripts/unmount.sh
+++ b/scripts/unmount.sh
@@ -34,14 +34,27 @@ if [ -n "$BSD" ]; then
     rm -f "$CONTAINER_DIR/active-$BSD.json" "$CONTAINER_DIR/tree-$BSD.json"
 fi
 
-# Detach the dummy disk image if it's attached and nothing else uses it.
-IMG="$HOME/Library/Application Support/TestFS/dummy.img"
-IMG_DEV=$(hdiutil info 2>/dev/null \
-    | awk -v img="$IMG" '
-        /^image-path/ { path = $3; for (i=4; i<=NF; i++) path = path " " $i }
-        /^\/dev\/disk/ && path == img { print $1; exit }
-    ')
-if [ -n "$IMG_DEV" ] && ! mount | grep -q "^$IMG_DEV "; then
-    echo "Detaching $IMG_DEV"
-    hdiutil detach "$IMG_DEV" || true
+# The host writes one image per mount under TestFS/dummies/, so we
+# can't match by a fixed filename — resolve the device through the
+# mount table instead, then sweep stragglers by image directory.
+if [ -n "$DEV" ]; then
+    echo "Detaching $DEV"
+    hdiutil detach "$DEV" || true
 fi
+
+# Sweep orphan attachments: anything under TestFS/dummies/ that's
+# still attached but no longer mounted (left over from previous
+# unclean unmounts or app-driven mounts that never ran this script).
+DUMMIES_DIR="$HOME/Library/Application Support/TestFS/dummies/"
+hdiutil info 2>/dev/null \
+    | awk -v dir="$DUMMIES_DIR" '
+        /^image-path/ { path = $3; for (i=4; i<=NF; i++) path = path " " $i }
+        /^\/dev\/disk/ && index(path, dir) == 1 { print $1 "\t" path }
+    ' \
+    | while IFS=$'\t' read -r dev img_path; do
+        [ -z "$dev" ] && continue
+        if ! mount | grep -q "^$dev "; then
+            echo "Detaching orphan $dev ($img_path)"
+            hdiutil detach "$dev" || true
+        fi
+    done


### PR DESCRIPTION
Fixes #23.

`scripts/unmount.sh` was looking for a singleton `dummy.img` to detach. `MountManager.prepareMount` writes per-mount `dummy-<UUID>.img` files under `~/Library/Application Support/TestFS/dummies/`, so the lookup hasn't matched anything app-driven for ages — every CLI unmount of an app mount left an orphan `/dev/diskN` attached.

Replace with two passes:

1. Detach the device the existing mount-table lookup at the top of the script already identified (`$DEV`). Decoupled from the app's filename scheme.
2. Walk `hdiutil info`, find any image attached under the `dummies/` directory that's no longer in the mount table, detach. Catches older leaks and crash-leftovers.

Match-by-directory instead of match-by-filename-prefix so the script doesn't break the next time the app's image-naming scheme changes.

## Manual verification

```sh
# Mount via the app a few times.
# Run scripts/unmount.sh per mount.
# Confirm: hdiutil info | grep -c TestFS/dummies/  → 0
```

## Verification

- `bash -n scripts/unmount.sh`: syntax OK
- `swift test`: 98 tests pass (no Swift change)
- `swiftlint --strict`: 0 violations
- `xcodebuild ... build`: succeeds