### PR TITLE
Reregister extension via actor; gate stamp on real mount, not commands

### DIFF
--- a/TestFS/ContentView+Helpers.swift
+++ b/TestFS/ContentView+Helpers.swift
@@ -22,8 +22,7 @@ enum AppEnvironment {
     static let icon: Image = Image(nsImage: NSApplication.shared.applicationIconImage)
         .resizable()
 
-    /// Re-register and re-enable the FSKit extension when the running
-    /// build differs from the last one we did this for. Four steps:
+    /// Re-register and re-enable the FSKit extension. Four steps:
     ///
     ///   1. `lsregister -f <app>` — kicks LaunchServices to re-ingest
     ///      the bundle so its database has the post-update version.
@@ -35,19 +34,19 @@ enum AppEnvironment {
     ///      → "user-enabled" (the `+` flag).
     ///
     /// Steps 3 + 4 are the toggle cycle — the same off-then-on flip
-    /// that System Settings → Login Items & Extensions → File System
-    /// Extensions does. The state *transition* is what forces
-    /// `extensionkitd` to drop its cached UUID for the appex and
-    /// re-resolve against the current bundle. Just calling `-e use`
-    /// against an already-`+` extension is a no-op and doesn't kick
-    /// `extensionkitd`, which is why mount kept failing with
-    /// `extensionKit.errorDomain error 2 / File system named testfs
-    /// not found` even after we'd run all the other steps.
+    /// that System Settings does. The state *transition* is what
+    /// forces `extensionkitd` to drop its cached UUID for the appex
+    /// and re-resolve against the current bundle.
+    ///
+    /// Don't gate the "did this work" stamp on shell-command success:
+    /// pluginkit succeeding is not proof that `extensionkitd` resolves
+    /// the new bundle. Only a successful mount is proof. The mount
+    /// path stamps `verifiedMountedVersion` on success; while that
+    /// stamp doesn't match `versionLabel`, this re-runs every launch.
     ///
     /// All four commands run as the user, no admin required.
-    static func reregisterExtensionIfNeeded() {
-        let key = "lastRegisteredVersion"
-        let last = UserDefaults.standard.string(forKey: key) ?? ""
+    static func performReregisterIfNeeded() {
+        let last = UserDefaults.standard.string(forKey: "verifiedMountedVersion") ?? ""
         guard versionLabel != last else { return }
 
         let appBundle = Bundle.main.bundleURL
@@ -59,18 +58,10 @@ enum AppEnvironment {
             + "/Versions/A/Frameworks/LaunchServices.framework"
             + "/Versions/A/Support/lsregister"
         let bundleID = TestFSConstants.extensionBundleID
-        let ok1 = runSilently(lsregister, ["-f", appBundle.path])
-        let ok2 = runSilently("/usr/bin/pluginkit", ["-a", appex.path])
-        let ok3 = runSilently("/usr/bin/pluginkit", ["-e", "ignore", "-i", bundleID])
-        let ok4 = runSilently("/usr/bin/pluginkit", ["-e", "use", "-i", bundleID])
-
-        // Stamp the version only if all four commands succeeded.
-        // A transient failure here means we should retry on next
-        // launch instead of permanently giving up until the next
-        // version bump.
-        if ok1 && ok2 && ok3 && ok4 {
-            UserDefaults.standard.set(versionLabel, forKey: key)
-        }
+        runSilently(lsregister, ["-f", appBundle.path])
+        runSilently("/usr/bin/pluginkit", ["-a", appex.path])
+        runSilently("/usr/bin/pluginkit", ["-e", "ignore", "-i", bundleID])
+        runSilently("/usr/bin/pluginkit", ["-e", "use", "-i", bundleID])
     }
 
     @discardableResult
@@ -87,6 +78,26 @@ enum AppEnvironment {
         } catch {
             return false
         }
+    }
+}
+
+/// One-shot serialization of `performReregisterIfNeeded`. The first
+/// caller spawns the work; later/parallel callers `await` the same
+/// task value. Mount path uses this to ensure post-update toggling
+/// has finished before invoking `mount(8)` — without it the
+/// app-init kickoff and the user's first Mount click race, and
+/// extensionkitd can resolve a stale UUID.
+actor ExtensionReregistration {
+    static let shared = ExtensionReregistration()
+    private var task: Task<Void, Never>?
+
+    func ensureCompleted() async {
+        if task == nil {
+            task = Task.detached(priority: .userInitiated) {
+                AppEnvironment.performReregisterIfNeeded()
+            }
+        }
+        await task?.value
     }
 }
 

--- a/TestFS/ContentView.swift
+++ b/TestFS/ContentView.swift
@@ -198,12 +198,9 @@ struct ContentView: View {
     private func mountSelected() async {
         guard let json = pickedJSON, let mnt = pickedMountpoint else { return }
         busy = true; defer { busy = false }
-
-        if MountTable.isMountpoint(mnt.path) {
-            alreadyMountedPath = mnt.path
-            return
-        }
-
+        guard !recordIfAlreadyMounted(at: mnt.path) else { return }
+        // Don't race app-init's re-registration kickoff.
+        await ExtensionReregistration.shared.ensureCompleted()
         status = "mounting \(json.lastPathComponent) at \(mnt.path)…"
 
         let accessing = json.startAccessingSecurityScopedResource()
@@ -258,6 +255,14 @@ struct ContentView: View {
         await recordSuccessfulMount(
             prep: prep, mountpoint: mnt.path,
             sourceJSON: json.path, volumeName: toMount.volumeName)
+    }
+
+    private func recordIfAlreadyMounted(at path: String) -> Bool {
+        if MountTable.isMountpoint(path) {
+            alreadyMountedPath = path
+            return true
+        }
+        return false
     }
 
     private func recordSuccessfulMount(

--- a/TestFS/TestFSApp.swift
+++ b/TestFS/TestFSApp.swift
@@ -38,14 +38,9 @@ struct TestFSApp: App {
         // Release it's solid black; in Debug it's solid red so a dev
         // build stands out from a shipped one at a glance.
         applyIconBadge()
-        // Re-register the FSKit extension after a Sparkle update so
-        // extensionkitd's adjudication doesn't go stale. Detached so
-        // the ~hundreds-of-ms shell-out doesn't hold up the first
-        // scene render; mount can't happen until the user clicks the
-        // button anyway, which gives this plenty of time to complete.
-        Task.detached(priority: .userInitiated) {
-            AppEnvironment.reregisterExtensionIfNeeded()
-        }
+        // Kick off post-update extension re-registration. Mount path
+        // awaits the same actor task to avoid racing this kickoff.
+        Task { await ExtensionReregistration.shared.ensureCompleted() }
     }
 
     @Environment(\.openWindow) private var openWindow


### PR DESCRIPTION
Fixes #21.

Two coupled defects in the post-update extension re-registration:

1. **Race.** App init kicked off the four-step toggle in `Task.detached`. The user's first **Mount** click could race that task — `extensionkitd` then resolved a stale UUID and `mount(8)` failed with `extensionKit.errorDomain error 2`. New `actor ExtensionReregistration` with `ensureCompleted()` cached-task pattern: app-init triggers it, `mountSelected` awaits the same task before invoking `mount(8)`. The mount path is guaranteed to see the post-toggle state.

2. **Cached without proof.** `lastRegisteredVersion` was stamped on shell-command success. `pluginkit -e use` succeeding is not proof that `extensionkitd` resolves the new bundle — and one launch where it lagged would suppress retries for the entire version. Drop `lastRegisteredVersion` (was redundant). Gate the toggle on `verifiedMountedVersion` (already stamped only after a real successful mount). The toggle re-runs every launch until a mount actually works at this version — self-healing.

Also extracted `recordIfAlreadyMounted(at:)` from `mountSelected` to keep its body under SwiftLint's `function_body_length` budget after the new `await` line landed; the helper name signals the side-effect on `alreadyMountedPath`.

## Verification

- `swift test`: 98 tests pass
- `swiftlint --strict`: 0 violations
- `xcodebuild ... build`: succeeds
- Manual smoke (post-merge in 0.1.15): bump version, install via Sparkle, click Mount immediately on first launch — the await on the actor should serialize correctly and mount should succeed without manual System Settings toggling.

## Notes on test coverage

The race + probe-stamp logic exercises real macOS process state (`Process` invocations, UserDefaults across launches, extensionkitd resolution) that can't be exercised from `swift test`. No SPM red regression test for this fix; verification is by `xcodebuild` + manual smoke after merge. Same pattern as #17 / #23.