### PR TITLE
install.sh: rebuild current checkout into repo-local DerivedData

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,22 +8,23 @@ REPO="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO"
 
 LSREGISTER=/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister
-DERIVED_GLOB=~/Library/Developer/Xcode/DerivedData/TestFS-*/Build/Products/Debug/TestFS.app
 
-# Build if there's no existing DerivedData output.
-if ! ls $DERIVED_GLOB 1>/dev/null 2>&1; then
-    echo "No built TestFS.app found; running xcodebuild build..."
-    xcodebuild -project TestFS.xcodeproj \
-        -scheme TestFS \
-        -configuration Debug \
-        -destination 'platform=macOS' \
-        -allowProvisioningUpdates \
-        build
-fi
+# Always rebuild from the current checkout — the previous "skip if any
+# DerivedData exists" short-circuit could pick up an unrelated clone's
+# bundle from the shared `~/Library/Developer/Xcode/DerivedData/TestFS-*`
+# pool. Build into the repo's own derived path so SRC_APP is unambiguous.
+echo "Building TestFS into build/derived..."
+xcodebuild -project TestFS.xcodeproj \
+    -scheme TestFS \
+    -configuration Debug \
+    -destination 'platform=macOS' \
+    -derivedDataPath "$REPO/build/derived" \
+    -allowProvisioningUpdates \
+    build
 
-SRC_APP="$(ls -d $DERIVED_GLOB | head -1)"
+SRC_APP="$REPO/build/derived/Build/Products/Debug/TestFS.app"
 if [ ! -d "$SRC_APP" ]; then
-    echo "FAIL: could not locate built TestFS.app"
+    echo "FAIL: expected build output at $SRC_APP"
     exit 1
 fi
 
@@ -52,11 +53,10 @@ echo "Installing $SRC_APP to /Applications/TestFS.app"
 rm -rf /Applications/TestFS.app
 cp -R "$SRC_APP" /Applications/TestFS.app
 
-# Register only the /Applications copy. Unregister SRC_APP afterwards so
-# the just-built DerivedData bundle doesn't compete for the same
-# pluginkit fstype slot — that's exactly the duplication that bit us.
+# Register only the /Applications copy. SRC_APP under build/derived/
+# was already swept by the prune loop above, so it can't compete for
+# the same pluginkit fstype slot.
 "$LSREGISTER" -f /Applications/TestFS.app
-"$LSREGISTER" -u "$SRC_APP" 2>/dev/null || true
 
 APPEX=/Applications/TestFS.app/Contents/Extensions/TestFSExtension.appex
 if [ -d "$APPEX" ]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -122,7 +122,7 @@ echo ""
 echo "=== sparkle: sign update ==="
 # Multiple DerivedData dirs (TestFS-<hash>) can pile up if the project is
 # cloned to several paths. -td picks the most recently modified one, which
-# is the one the just-completed archive populated. Same idiom as install.sh.
+# is the one the just-completed archive populated.
 SPARKLE_BIN_GLOB=~/Library/Developer/Xcode/DerivedData/TestFS-*/SourcePackages/artifacts/sparkle/Sparkle/bin
 SPARKLE_BIN="$(ls -td $SPARKLE_BIN_GLOB 2>/dev/null | head -1)"
 if [ -z "$SPARKLE_BIN" ] || [ ! -x "$SPARKLE_BIN/sign_update" ]; then


### PR DESCRIPTION
Fixes #33.

`scripts/install.sh` short-circuited the `xcodebuild` if any `~/Library/Developer/Xcode/DerivedData/TestFS-*` tree existed and then picked `head -1` (lexicographic, not newest, not tied to the current clone). On a machine with multiple clones of the repo, this could install an older clone's app silently — feeding straight back into the stale-extension debugging hell that #21 + the lsregister sweep were meant to clear.

## Changes

- Drop the conditional. Always run `xcodebuild` from the current checkout.
- Pass `-derivedDataPath "$REPO/build/derived"` so the build output lands under the repo, eliminating cross-clone ambiguity entirely. Same path Xcode IDE never touches.
- `SRC_APP` is now a deterministic constant: `$REPO/build/derived/Build/Products/Debug/TestFS.app`.
- Drop the redundant `lsregister -u "$SRC_APP"` after the install — the prune loop above already covers `build/derived/Build/Products/*/TestFS.app`.
- `release.sh`: drop the now-stale "Same idiom as install.sh" comment that referred to the old `head -1` lookup.

## Verification

- `bash -n scripts/install.sh`: syntax OK
- `bash -n scripts/release.sh`: syntax OK
- `swift test`: 98 tests pass (no Swift change)
- `swiftlint --strict`: 0 violations
- Manual: run `scripts/install.sh` from a checkout where `~/Library/Developer/Xcode/DerivedData/TestFS-*/Build/Products/Debug/TestFS.app` exists from a different clone — installs from the current clone now.

## Notes

The unconditional rebuild trades a few seconds of xcodebuild's incremental cache for correctness. If install latency becomes painful for fast-iteration workflows, revisit then; for now YAGNI.