### PR TITLE
update_appcast: replace existing item for same version on rerun

### DIFF
--- a/scripts/update_appcast.rb
+++ b/scripts/update_appcast.rb
@@ -33,6 +33,16 @@ enclosure.attributes["type"] = "application/octet-stream"
 
 item.add_element("sparkle:minimumSystemVersion").text = "15.4"
 
+# Re-notarize/re-sign produces a new edSignature for the same
+# version; drop any stale entry to avoid ambiguous duplicates.
+# Materialize via to_a first — REXML's `elements.each` walks an
+# internal array by index, so mutating during iteration skips the
+# entry after each delete.
+channel.elements.to_a("item").each do |existing|
+  short = existing.elements["sparkle:shortVersionString"]
+  channel.delete_element(existing) if short && short.text == version
+end
+
 first_item = channel.elements["item"]
 first_item ? channel.insert_before(first_item, item) : channel.add_element(item)
 


### PR DESCRIPTION
Fixes #35.

`scripts/update_appcast.rb` unconditionally prepended a new `<item>` to the feed. A re-notarize + rerun for the same version (which produces a new `edSignature`) left two items with the same `sparkle:shortVersionString` and different signatures. Sparkle picks the first one, so it usually still works, but the feed becomes ambiguous.

Walk `channel/item` before insert and remove any with a matching `sparkle:shortVersionString`.

The walk uses `channel.elements.to_a("item").each` rather than `channel.elements.each("item")` — REXML's `each` walks an internal Array by index and `delete_element` shifts that array, so iterating + deleting in the same pass skips the entry after each deletion. Materializing via `to_a` first is the standard fix.

## Verification

- Single duplicate test: run script twice with same version → 1 entry remains, with the latest signature.
- Two-pre-existing-duplicates stress test (synthesized to provoke the iteration-mutation gotcha): run once → both pre-existing copies removed, one new entry remains.
- `swift test`: 98 tests pass (no Swift change)
- `swiftlint --strict`: 0 violations