### PR TITLE
mount.sh: encode sidecar JSON via python3 instead of heredoc

### DIFF
--- a/scripts/mount.sh
+++ b/scripts/mount.sh
@@ -52,12 +52,18 @@ mkdir -p "$CONTAINER_DIR"
 TREE="$CONTAINER_DIR/tree-$BSD.json"
 SIDECAR="$CONTAINER_DIR/active-$BSD.json"
 cp "$CONFIG_ABS" "$TREE"
-cat > "$SIDECAR" <<EOF
-{
-  "config": "$TREE",
-  "volume_name": "$(basename "$CONFIG_ABS" .json)"
-}
-EOF
+# Encode via python3: bash has no JSON encoder, and a path or volume
+# name with `"`, `\`, or newline would break a heredoc. The python
+# body is static — pass any new sidecar field via env vars too,
+# never inline shell-interpolated.
+TREE_PATH="$TREE" VOLUME_NAME="$(basename "$CONFIG_ABS" .json)" \
+    /usr/bin/python3 -c '
+import json, os, sys
+sys.stdout.write(json.dumps({
+    "config": os.environ["TREE_PATH"],
+    "volume_name": os.environ["VOLUME_NAME"],
+}))
+' > "$SIDECAR"
 echo "Staged $TREE (from $CONFIG_ABS)"
 echo "Wrote   $SIDECAR"
 


### PR DESCRIPTION
Fixes #34.

`scripts/mount.sh` wrote the sidecar JSON via heredoc with shell interpolation. A POSIX-valid filename containing `"`, `\`, or a newline produced malformed JSON; the failure surfaced inside `loadResource` as a fake parse error instead of at staging time.

Bash has no JSON encoder. `/usr/bin/python3` is always present on macOS — pass field values via env vars so shell escaping never reaches the encoder, and lock that invariant in a comment so future fields don't drift back to inline interpolation.

## Verification

- `bash -n scripts/mount.sh`: syntax OK
- Encoding test with `path='/tmp/has"quote\and\\backslash and<newline>name.json'` and `volume_name='vol"with\nasties'` → JSON parses round-trip clean.
- `swift test`: 98 tests pass (no Swift change)
- `swiftlint --strict`: 0 violations