### PR TITLE
MountRegistry: drop stale row when /dev/diskN reuse moves the mountpoint

### DIFF
--- a/TestFS/MountRegistry.swift
+++ b/TestFS/MountRegistry.swift
@@ -40,16 +40,18 @@ actor MountRegistry {
         Array(byBSD.values).sorted(by: { $0.mountedAt < $1.mountedAt })
     }
 
-    /// Ground-truth from the kernel. Adds entries we didn't know
-    /// about; preserves source/volume metadata on entries we already
-    /// had; drops entries no longer mounted. Returns the post-
-    /// reconciliation snapshot so callers don't need a separate hop.
+    /// Ground-truth from the kernel. Preserves source/volume metadata
+    /// only when both the BSD name AND the mountpoint match — `diskN`
+    /// values are recyclable, so the kernel can hand the same name
+    /// back out to a different mount. If the mountpoint flipped,
+    /// treat the row as new (the old `sourceJSON`/`volumeName` aren't
+    /// transferable to a different mount).
     func refreshed() -> [MountRecord] {
         let live = TestFSMountScanner.scan()
         var fresh: [String: MountRecord] = [:]
         let now = Date()
         for entry in live {
-            if let existing = byBSD[entry.bsdName] {
+            if let existing = byBSD[entry.bsdName], existing.mountpoint == entry.mountpoint {
                 fresh[entry.bsdName] = existing
             } else {
                 fresh[entry.bsdName] = MountRecord(


### PR DESCRIPTION
Fixes #31.

`MountRegistry.refreshed()` keyed by `bsdName` and reused the entire old record when the key matched. macOS recycles `/dev/diskN` names — if a testfs mount goes away and another grabs the same name before the next UI refresh, the row preserved the prior `mountpoint` / `sourceJSON` / `volumeName` even though the kernel mount is a different volume. The UI then showed wrong metadata, and the **Unmount** button could act on the stale path while describing a different live kernel mount.

## Change

Preserve the existing record only when both `bsdName` AND `mountpoint` match. If the mountpoint flipped, treat as a new row — `sourceJSON` / `volumeName` aren't transferable to a different mount, so they're dropped (re-discovered as `nil`, same as a CLI-initiated mount).

`devNodePath` equality isn't checked because `bsdName = .bsdName(fromDevNode: devNodePath)` is 1:1 by construction.

## Verification

- `swift test`: 98 tests pass (no SPM-reachable test for `MountRegistry` — host-only zone)
- `swiftlint --strict`: 0 violations
- `xcodebuild ... build`: succeeds
- Manual repro: mount A in app, unmount A externally + immediately mount B reusing the same `/dev/diskN`, press **Refresh** — row shows B's mountpoint with no stale A metadata.