### PR TITLE
ShellRunner: per-call subprocess timeout (default 30s)

### DIFF
--- a/TestFS/ShellRunner.swift
+++ b/TestFS/ShellRunner.swift
@@ -20,13 +20,24 @@ enum ShellRunner {
     private static let drainQueue = DispatchQueue(
         label: "shellrunner.drain", attributes: .concurrent)
 
-    static func run(_ path: String, _ args: [String]) -> Result {
+    /// Default ceiling for any single subprocess. A wait longer than
+    /// this means the system process is wedged and the caller should
+    /// fail loud rather than block its actor.
+    static let defaultTimeout: TimeInterval = 30.0
+
+    static func run(
+        _ path: String,
+        _ args: [String],
+        timeout: TimeInterval = defaultTimeout
+    ) -> Result {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: path)
         proc.arguments = args
         let outPipe = Pipe(), errPipe = Pipe()
         proc.standardOutput = outPipe
         proc.standardError = errPipe
+        let exitSem = DispatchSemaphore(value: 0)
+        proc.terminationHandler = { _ in exitSem.signal() }
         do { try proc.run() } catch {
             return Result(exit: -1, stdout: "", stderr: error.localizedDescription)
         }
@@ -42,7 +53,24 @@ enum ShellRunner {
             errData = errPipe.fileHandleForReading.readDataToEndOfFile()
             group.leave()
         }
-        proc.waitUntilExit()
+        if exitSem.wait(timeout: .now() + timeout) == .timedOut {
+            // SIGTERM first; if the child traps it (or is stuck in
+            // uninterruptible I/O), the pipes stay open and the drain
+            // reads block forever — defeating the timeout. Escalate
+            // to SIGKILL after 2s, then bound the drain wait so
+            // group.wait can't itself hang.
+            proc.terminate()
+            if exitSem.wait(timeout: .now() + 2.0) == .timedOut {
+                kill(proc.processIdentifier, SIGKILL)
+                _ = exitSem.wait(timeout: .now() + 1.0)
+            }
+            _ = group.wait(timeout: .now() + 1.0)
+            return Result(
+                exit: -1,
+                stdout: String(data: outData, encoding: .utf8) ?? "",
+                stderr: "ShellRunner: \(path) timed out after \(timeout)s"
+            )
+        }
         group.wait()
         return Result(
             exit: proc.terminationStatus,


### PR DESCRIPTION
Fixes #42.

`ShellRunner.run` did `proc.waitUntilExit()` with no deadline. Every host-side subprocess in `MountManager` (mkfile, hdiutil attach/detach/info, mount, umount) goes through it. One stalled child wedged the entire `MountManager` actor — every later mount/unmount/sweep request queued behind the actor and never returned.

#32 fixed this for `ExtensionReregistration`'s `runSilently`. I explicitly punted on `ShellRunner` in that PR; the round-3 audit correctly flagged it.

## Changes

- `defaultTimeout: TimeInterval = 30.0` (real callers finish in well under a second; headroom covers macOS 26 cold-start spikes).
- `run(_:_:timeout:)` accepts an override. `DispatchSemaphore` + `terminationHandler` for the bounded wait.
- **On timeout:** `proc.terminate()` (SIGTERM), wait 2s for natural exit, escalate to `kill(pid, SIGKILL)` if still alive, bound the drain `group.wait` at 1s. A child that traps SIGTERM or sits in uninterruptible I/O can't keep the pipes open and hang the drain readers — closes the audit's specific concern about unbounded `group.wait`.
- Returns `Result(exit: -1, ..., stderr: "ShellRunner: <path> timed out after <s>")` so `MountManager.toolError` surfaces a useful message.

## Verification

- `swift test`: 98 tests pass (no SPM-reachable test for `ShellRunner` — host-target Process)
- `swiftlint --strict`: 0 violations
- `xcodebuild ... build`: succeeds
- Manual smoke (post-merge): `kill -STOP` on a child mid-mount, observe `MountManager.mount` returns the timeout-flagged failure within 30s instead of hanging the actor.

## Out of scope

`runSilently` in `ContentView+Helpers.swift` (added in #32) duplicates this shape; would benefit from extraction into a shared `Process+timeout` helper. Filed mentally for follow-up — this PR's scope is only the audit-flagged hang vector.