### PR TITLE
TestFSVolume: ENOTDIR when lookupItem/enumerateDirectory hit a file

### DIFF
--- a/TestFSExtension/TestFSVolume+Ops.swift
+++ b/TestFSExtension/TestFSVolume+Ops.swift
@@ -116,6 +116,8 @@ extension TestFSVolume: FSVolume.Operations {
     ) async throws -> (FSItem, FSFileName) {
         try await throttle.gate()
         let dir = try requireTestItem(directory)
+        // POSIX: traversing through a non-directory is ENOTDIR, not ENOENT.
+        guard dir.node.kind == .directory else { throw posixError(.ENOTDIR) }
         let nameString = name.string ?? ""
         guard let child = index.lookup(name: nameString, in: dir.node.id),
             let item = itemsByID[child.id]
@@ -154,6 +156,8 @@ extension TestFSVolume: FSVolume.Operations {
     ) async throws -> FSDirectoryVerifier {
         try await throttle.gate()
         let dir = try requireTestItem(directory)
+        // POSIX: traversing through a non-directory is ENOTDIR, not ENOENT.
+        guard dir.node.kind == .directory else { throw posixError(.ENOTDIR) }
         if options.verbose {
             Log.lookup.debug(
                 "enumerate '\(dir.node.name, privacy: .public)' from cookie \(cookie.rawValue)")


### PR DESCRIPTION
Fixes #43.

`lookupItem(named:inDirectory:)` and `enumerateDirectory(...)` accepted any FSItem and treated a file as if it had no children. `ls /mnt/file/x` returned ENOENT instead of ENOTDIR; `readdir` on a file returned an empty enumeration. POSIX/FSKit contract violation — tools that key off errno (rsync, find, shell completion) get the wrong signal.

Add `guard dir.node.kind == .directory else { throw posixError(.ENOTDIR) }` at the top of both ops with a one-line WHY comment.

The mutating ops (createItem, removeItem, renameItem, etc.) already throw EROFS unconditionally so they don't need the guard. The `read(...)` op already uses the same inline-guard pattern with EISDIR.

## Verification

- `swift test`: 98 tests pass (no SPM-reachable test for `TestFSVolume+Ops` — FSKit-only zone)
- `swiftlint --strict`: 0 violations
- `xcodebuild ... build`: succeeds
- Manual smoke (post-merge): `ls /mnt/somefile/x` returns `Not a directory` (errno 20).