### PR TITLE
MountManager: pre-flight tree JSON + TreeBuilder (#46 part 1)

### DIFF
--- a/TestFS/MountManager.swift
+++ b/TestFS/MountManager.swift
@@ -45,6 +45,13 @@ actor MountManager {
     /// owns only the mount-specific `config` field (= staged tree
     /// path) and sidecar serialization.
     func prepareMount(treeJSON: Data, options: MountOptions) throws -> PrepareResult {
+        // Pre-flight: surface JSON / TreeBuilder errors before
+        // allocating a dev node. Otherwise they only fire inside the
+        // extension's loadResource, and the host eats the full 15s
+        // confirmMountedOrRollback budget for what is a synchronous
+        // validation failure.
+        _ = try TreeBuilder.parseAndBuild(treeJSON: treeJSON, options: options)
+
         var imageURL: URL?
         var devNode: String?
         var stagedTree: URL?

--- a/TestFSExtension/TestFileSystem.swift
+++ b/TestFSExtension/TestFileSystem.swift
@@ -59,8 +59,7 @@ final class TestFileSystem: FSUnaryFileSystem, FSUnaryFileSystemOperations {
             let mountOptions = try MountOptions.load(from: sidecarURL)
             let configPath = mountOptions.config!
             let treeData = try Data(contentsOf: URL(fileURLWithPath: configPath), options: .mappedIfSafe)
-            let tree = try JSONTree.load(from: treeData)
-            let index = try TreeBuilder.build(root: tree, options: mountOptions)
+            let index = try TreeBuilder.parseAndBuild(treeJSON: treeData, options: mountOptions)
             let volume = TestFSVolume(index: index, options: mountOptions)
             containerStatus = .ready
             let nodeCount = index.nodesByID.count

--- a/TestFSExtension/TreeBuilder.swift
+++ b/TestFSExtension/TreeBuilder.swift
@@ -78,6 +78,15 @@ enum TreeBuilder {
         )
     }
 
+    /// Decode the tree JSON and build the index in one call. Both
+    /// the host's `prepareMount` pre-flight and the extension's
+    /// `loadResource` go through this so the two sites can't drift
+    /// on the validation contract.
+    static func parseAndBuild(treeJSON: Data, options: MountOptions) throws -> TreeIndex {
+        let root = try JSONTree.load(from: treeJSON)
+        return try build(root: root, options: options)
+    }
+
     /// Returns (id, normalized-name) so the caller doesn't have to
     /// re-look-up the just-inserted node when checking for collisions.
     private static func visit(


### PR DESCRIPTION
First half of #46. **Does not close the issue** — the failure-marker channel for FSKit-runtime errors lands as a follow-up PR.

The 15s `confirmMountedOrRollback` budget (#20) covers legitimate cold-start delay, but mounts that fail deterministically inside `loadResource` (malformed tree JSON, `BuildError.duplicateName`, `BuildError.totalSizeOverflow`, ...) still wait the full 15s before rollback fires — `mount(8)` returns success, only the extension's `loadResource` sees the bad input.

## Changes

- New `TreeBuilder.parseAndBuild(treeJSON:options:)` convenience that runs `JSONTree.load` then `TreeBuilder.build`. Single source of truth for the host pre-flight + the extension's `loadResource`, so they can't drift on the validation contract.
- `MountManager.prepareMount` calls it at the top, before any block-device allocation. Errors propagate via the existing `prepareMount failed: <error>` path with the underlying `BuildError`/`JSONTree.LoadError` description (e.g. `prepareMount failed: file size overflows volume accounting in 'r': 'huge'`).
- `TestFileSystem.loadResource` now also calls the new helper instead of inlining the two-step parse+build.

## What this catches at zero cross-process cost

- Malformed top-level JSON (non-array, empty, garbage).
- Trailing entries past element 0 (post-#22).
- Unknown node `type`.
- `BuildError.duplicateName` (case-fold-or-normalization-equivalent siblings, post-#14).
- `BuildError.totalSizeOverflow` (post-#18).

## What this does NOT catch (PR B will)

- FSKit volume creation failures inside the extension.
- Transient I/O / sandbox-permission errors when the extension reads its container.

## Verification

- `swift test`: 98 tests pass — the validation logic is already SPM-tested via `JSONTreeTests` + `TreeBuilderTests`; the helper is just routing.
- `swiftlint --strict`: 0 violations.
- `xcodebuild ... build`: succeeds.
- Manual smoke (post-merge): stage a sidecar pointing at a malformed tree JSON, click Mount, observe immediate `prepareMount failed: ...` instead of a 15-second wait.

## Refs

Refs #46 (closes after PR B lands).