### PR TITLE
Failure marker channel: extension surfaces loadResource error to host

### DIFF
--- a/TestFS/ContentView+Helpers.swift
+++ b/TestFS/ContentView+Helpers.swift
@@ -142,6 +142,25 @@ extension ContentView {
         }
     }
 
+    /// Translate a `MountConfirmResult` into UI status text. Returns
+    /// `true` if the mount succeeded, `false` after writing status
+    /// text describing the failure (caller should `return` early).
+    func handleConfirmResult(_ result: MountManager.MountConfirmResult) -> Bool {
+        switch result {
+        case .mounted:
+            return true
+        case .failed(.some(let reason)):
+            status = "Mount failed: \(reason)"
+            return false
+        case .failed(.none):
+            status =
+                "Mount failed: the kernel accepted the mount but the FSKit "
+                + "extension didn't report a result within 15s. Open Show "
+                + "log… for diagnostics."
+            return false
+        }
+    }
+
     @ViewBuilder
     var extensionDisabledBanner: some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {

--- a/TestFS/ContentView.swift
+++ b/TestFS/ContentView.swift
@@ -241,16 +241,9 @@ struct ContentView: View {
         // loadResource runs asynchronously and can still fail. Verify
         // the volume actually came up before recording it, otherwise
         // the UI shows a phantom mount that doesn't serve file data.
-        let confirmed = await MountManager.shared.confirmMountedOrRollback(
+        let result = await MountManager.shared.confirmMountedOrRollback(
             prep: prep, mountpoint: mnt.path)
-        guard confirmed else {
-            status =
-                "Mount failed: the kernel accepted the mount but the FSKit "
-                + "extension didn't load the volume. Open Show log… for the "
-                + "extension's error (JSON parse error, missing config, "
-                + "or similar)."
-            return
-        }
+        guard handleConfirmResult(result) else { return }
 
         await recordSuccessfulMount(
             prep: prep, mountpoint: mnt.path,

--- a/TestFS/MountManager.swift
+++ b/TestFS/MountManager.swift
@@ -83,6 +83,9 @@ actor MountManager {
             let sidecar = try Self.sidecarEncoder.encode(sidecarOptions)
             try sidecar.write(to: paths.sidecar, options: .atomic)
 
+            // Stage-time clear; see failureMarkerURL doc.
+            try? FileManager.default.removeItem(at: failureMarkerURL(forBSD: bsd))
+
             log.info("prepareMount: \(bsd, privacy: .public)")
             return PrepareResult(devNodePath: dev)
         } catch {
@@ -108,6 +111,7 @@ actor MountManager {
         let paths = sidecarPaths(forBSD: bsdName)
         try? FileManager.default.removeItem(at: paths.tree)
         try? FileManager.default.removeItem(at: paths.sidecar)
+        try? FileManager.default.removeItem(at: failureMarkerURL(forBSD: bsdName))
 
         // Image sweep is best-effort cleanup; pushing it off the
         // user-visible unmount path keeps the UI responsive.
@@ -151,6 +155,24 @@ actor MountManager {
             tree: dir.appendingPathComponent("tree-\(bsd).json"),
             sidecar: dir.appendingPathComponent("active-\(bsd).json")
         )
+    }
+
+    /// Per-BSD failure marker. Parallels
+    /// `MountOptions.failureMarkerURL(forBSDName:)` on the extension
+    /// side — they produce paths to the same physical file via
+    /// different mechanisms, the same way `sidecarPaths` parallels
+    /// `MountOptions.sidecarURL(forBSDName:)`. The host needs the
+    /// hand-built `extensionContainerDir` because `applicationSupportDirectory`
+    /// resolves to the host's own home, not the extension's sandbox.
+    fileprivate func failureMarkerURL(forBSD bsd: String) -> URL {
+        extensionContainerDir().appendingPathComponent("failed-\(bsd).json")
+    }
+
+    /// Read the extension-written failure marker. Returns the error
+    /// reason, or nil if the marker doesn't exist or is malformed.
+    fileprivate static func readFailureMarker(at url: URL) -> String? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(LoadFailureMarker.self, from: data).error
     }
 
     // MARK: - hdiutil / mkfile
@@ -225,37 +247,65 @@ actor MountManager {
     /// cheap (sub-microsecond VFS lookup).
     private static let mountConfirmPollInterval: Duration = .milliseconds(100)
 
+    /// Outcome of `confirmMountedOrRollback`. `.failed(reason:)` is
+    /// non-nil when the extension's `loadResource` wrote a failure
+    /// marker; `nil` means we hit the timeout without either a
+    /// statfs success or a marker (genuinely opaque hang).
+    enum MountConfirmResult {
+        case mounted
+        case failed(reason: String?)
+    }
+
     /// Verify the FSKit extension finished bringing up the volume
     /// after `mount(8)` returned. On failure, unmount + detach so
     /// we don't leave a phantom mount or an orphaned dev node.
-    func confirmMountedOrRollback(prep: PrepareResult, mountpoint: String) async -> Bool {
-        if await waitForMount(at: mountpoint) { return true }
-        try? unmount(at: mountpoint)
-        try? detach(bsdName: prep.bsdName)
-        return false
+    /// Returns whatever reason the extension wrote into the failure
+    /// marker (if any), so the caller can surface a useful status.
+    func confirmMountedOrRollback(
+        prep: PrepareResult, mountpoint: String
+    ) async -> MountConfirmResult {
+        let result = await waitForMount(prep: prep, mountpoint: mountpoint)
+        switch result {
+        case .mounted:
+            return .mounted
+        case .failed(let reason):
+            try? unmount(at: mountpoint)
+            try? detach(bsdName: prep.bsdName)
+            return .failed(reason: reason)
+        }
     }
 
-    /// Poll `statfs(2)` until the mountpoint reports `f_fstypename
-    /// == "testfs"`, or the timeout elapses. Uses `ContinuousClock`
-    /// so a sleep/wake mid-poll doesn't skew the deadline. No more
-    /// reliable oracle exists on macOS 26: NSWorkspace mount and
-    /// DiskArbitration "appeared" notifications fire on mount(8)
-    /// accept (before FSKit's loadResource finishes), so they'd
-    /// false-positive a phantom mount. statfs's `f_fstypename`
-    /// flips only once the volume is actually usable.
+    /// Poll for either statfs reporting `f_fstypename == "testfs"`
+    /// (mount loaded) or the extension's per-BSD failure marker
+    /// (loadResource failed). Whichever fires first wins, so
+    /// deterministic failures don't burn the full 15s budget. Uses
+    /// `ContinuousClock` so sleep/wake mid-poll doesn't skew the
+    /// deadline.
+    ///
+    /// statfs is the authoritative success signal — NSWorkspace and
+    /// DiskArbitration notifications fire on `mount(8)` accept,
+    /// before loadResource completes, so they'd false-positive.
+    /// The marker is the authoritative failure signal: extension
+    /// writes it before calling `replyHandler(nil, error)`. Stage-
+    /// time delete in `prepareMount` ensures we never see a stale
+    /// marker from a prior mount that reused this BSD name.
     func waitForMount(
-        at mountpoint: String,
+        prep: PrepareResult, mountpoint: String,
         timeout: Duration = mountConfirmTimeout
-    ) async -> Bool {
+    ) async -> MountConfirmResult {
+        let markerURL = failureMarkerURL(forBSD: prep.bsdName)
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: timeout)
         while clock.now < deadline {
             if Self.statfsType(at: mountpoint) == TestFSConstants.fstype {
-                return true
+                return .mounted
+            }
+            if let reason = Self.readFailureMarker(at: markerURL) {
+                return .failed(reason: reason)
             }
             try? await Task.sleep(for: Self.mountConfirmPollInterval)
         }
-        return false
+        return .failed(reason: nil)
     }
 
     /// Read `f_fstypename` from `statfs(2)`. Returns `nil` if the

--- a/TestFSExtension/MountOptions.swift
+++ b/TestFSExtension/MountOptions.swift
@@ -2,21 +2,13 @@
 //  MountOptions.swift
 //  TestFSCore / TestFSExtension
 //
-//  Sidecar config schema decoded by `loadResource` from a known path
-//  (~/Library/Application Support/TestFS/active.json by default). Pure
-//  Swift, compiled into both the SPM TestFSCore target and the Xcode
-//  FSKit extension target.
-//
-//  Defaults match Python `jsonfs.py`'s CLI defaults, not its constructor
-//  defaults — matching what a user running the Python tool would see.
+//  Sidecar schema + path helpers shared by host and extension.
+//  Defaults match Python jsonfs.py's CLI defaults.
 //
 
 import Foundation
 
-/// Identity strings shared by the host app and the extension. Lives
-/// in this file because `MountOptions.swift` is one of the few
-/// sources compiled into both the FSKit extension and the host
-/// app, giving us a single source of truth.
+/// Identity strings shared by host and extension.
 enum TestFSConstants {
     /// `os.Logger` subsystem used by both processes; the host's log
     /// viewer filters on this.
@@ -295,6 +287,13 @@ extension MountOptions: Codable {
     }
 }
 
+/// Shape of the failure-marker JSON the extension writes on
+/// `loadResource` error so the host can decode the underlying
+/// reason instead of polling blind for the full timeout.
+struct LoadFailureMarker: Codable {
+    let error: String
+}
+
 extension MountOptions {
     enum LoadError: Error, LocalizedError {
         case missingConfig
@@ -332,21 +331,22 @@ extension MountOptions {
     /// values, so this is safe to force-unwrap on a loaded instance.
     var blockSizeBytes: Int { parseSize(blockSize)! }
 
-    /// Per-device sidecar path. Each mount writes its own
-    /// `active-<bsdName>.json`, so concurrent mounts on distinct
-    /// /dev/diskN devices can serve different tree JSONs simultaneously.
-    ///
-    /// Lives in the extension's own sandbox Application Support —
-    /// `~/Library/Containers/com.sohonet.testfsmount.appex/Data/Library/
-    /// Application Support/TestFS/`. The extension reads its own
-    /// container without sandbox friction, and any non-sandboxed writer
-    /// (shell scripts, the host app) can write here as the user.
-    ///
-    /// The App Group container is NOT used: FSKit extensions appear to
-    /// get a stricter sandbox profile that denies reads from Group
-    /// Containers even with the `application-groups` entitlement present.
+    /// Per-device sidecar path under the extension's sandbox
+    /// container. Each mount writes its own `active-<bsdName>.json`
+    /// so concurrent mounts on distinct devices serve independent
+    /// tree JSONs. App Group containers are not used — FSKit
+    /// extensions get a stricter sandbox that denies group-container
+    /// reads even with the entitlement.
     static func sidecarURL(forBSDName bsd: String) -> URL {
         extensionContainerTestFSDir().appendingPathComponent("active-\(bsd).json")
+    }
+
+    /// Per-BSD failure marker. Extension writes this on
+    /// `loadResource` error before `replyHandler(nil, error)` so the
+    /// host's `confirmMountedOrRollback` can short-circuit the 15s
+    /// timeout and surface the underlying error.
+    static func failureMarkerURL(forBSDName bsd: String) -> URL {
+        extensionContainerTestFSDir().appendingPathComponent("failed-\(bsd).json")
     }
 
     /// Base directory for sidecar + staged tree JSON files in the

--- a/TestFSExtension/TestFileSystem.swift
+++ b/TestFSExtension/TestFileSystem.swift
@@ -67,6 +67,20 @@ final class TestFileSystem: FSUnaryFileSystem, FSUnaryFileSystemOperations {
                 "loadResource: \(nodeCount) nodes from \(configPath, privacy: .public) for \(bsd, privacy: .public)")
             replyHandler(volume, nil)
         } catch {
+            // Drop a per-BSD failure marker so the host's
+            // confirmMountedOrRollback can short-circuit the 15s
+            // timeout. Best-effort: log a write failure but keep the
+            // user-facing replyHandler call; the host then falls back
+            // to the timeout but the diagnostic is in the log.
+            let markerURL = MountOptions.failureMarkerURL(forBSDName: bsd)
+            do {
+                let data = try JSONEncoder().encode(
+                    LoadFailureMarker(error: error.localizedDescription))
+                try data.write(to: markerURL, options: .atomic)
+            } catch {
+                Log.mount.error(
+                    "failed to write failure marker: \(error.localizedDescription, privacy: .public)")
+            }
             Log.mount.error("loadResource failed: \(error.localizedDescription, privacy: .public)")
             replyHandler(nil, error)
         }


### PR DESCRIPTION
Fixes #46. Pairs with PR #52 (pre-flight validation) which landed first.

After PR #52 catches every host-decodable error in `prepareMount`, the remaining 15s waits come from FSKit-runtime failures inside `loadResource` that the host can't pre-validate. This PR adds a per-BSD failure marker file so deterministic extension-side errors short-circuit the timeout and surface a useful status message.

## Channel design

- Path: `~/Library/Containers/com.sohonet.testfsmount.appex/Data/Library/Application Support/TestFS/failed-<bsd>.json`.
- Shape: `LoadFailureMarker { error: String }` — Codable struct shared by both sides via `MountOptions.swift` (compiled into TestFSCore + extension target). Kills the drift risk of "agree on a `[String: String]` with key `"error"`" that bit us in #41/#44.
- **Extension** (`TestFileSystem.loadResource` catch path) writes via `JSONEncoder().encode(LoadFailureMarker(...))` before `replyHandler(nil, error)`. Best-effort: write failure logs to OSLog and falls back to the existing 15s timeout — but we'd see it in the diagnostic stream.
- **Host** (`MountManager.prepareMount`) deletes any pre-existing marker after staging the new sidecar. Stage-time clear means a recycled BSD can't false-trigger off a stale signal.
- **Host** (`MountManager.detach`) removes the marker as part of normal rollback cleanup.
- **Host** (`MountManager.waitForMount`) polls for either statfs success or marker existence on each 100ms tick. Whichever fires first wins. statfs is authoritative for success; marker is authoritative for failure.

## API change

`confirmMountedOrRollback` now returns a `MountConfirmResult` enum (`.mounted` / `.failed(reason: String?)`) rather than `Bool`. `nil` reason = timed out without a marker (genuinely opaque hang); non-nil = extension wrote a marker. `ContentView.mountSelected` switches via a new `handleConfirmResult` helper in `ContentView+Helpers` (kept the struct body under SwiftLint's 250-line budget).

## Path coordination

Both sides reach the same physical file via parallel helpers:
- `MountOptions.failureMarkerURL(forBSDName:)` from the extension (uses `applicationSupportDirectory` which resolves to its own sandbox).
- `MountManager.failureMarkerURL(forBSD:)` from the host (uses `extensionContainerDir()` which hand-builds `~/Library/Containers/<bundleID>/Data/...` because the host is unsandboxed and would otherwise resolve `applicationSupportDirectory` to its own home).

Same physical path, different code paths — same pattern as `MountOptions.sidecarURL` / `MountManager.sidecarPaths`.

## Verification

- `swift test`: 98 tests pass.
- `swiftlint --strict`: 0 violations.
- `xcodebuild ... build`: succeeds.
- Manual smoke (post-merge): malformed sidecar that survives pre-flight (e.g., a tree with a node referring to an unknown FSKit feature) triggers the marker; observe immediate `"Mount failed: <reason>"` in status text instead of a 15s wait.

## Companion to PR #52

PR #52 covered host-decodable errors via pre-flight `JSONTree.load` + `TreeBuilder.build`. This PR covers the FSKit-runtime / extension-side errors that pre-flight can't catch. Together they close #46.