### PR TITLE
Revert host-side pre-flight from #52: TreeBuilder isn't in host target

### DIFF
--- a/TestFS/MountManager.swift
+++ b/TestFS/MountManager.swift
@@ -45,12 +45,14 @@ actor MountManager {
     /// owns only the mount-specific `config` field (= staged tree
     /// path) and sidecar serialization.
     func prepareMount(treeJSON: Data, options: MountOptions) throws -> PrepareResult {
-        // Pre-flight: surface JSON / TreeBuilder errors before
-        // allocating a dev node. Otherwise they only fire inside the
-        // extension's loadResource, and the host eats the full 15s
-        // confirmMountedOrRollback budget for what is a synchronous
-        // validation failure.
-        _ = try TreeBuilder.parseAndBuild(treeJSON: treeJSON, options: options)
+        // NB: pre-flight `TreeBuilder.parseAndBuild` was removed —
+        // TestFSExtension's pure-Swift parsers aren't members of the
+        // host target, so the call doesn't compile from a clean
+        // build (PR #52 only worked through cached derived data).
+        // The marker channel (PR #53) catches the same failures via
+        // the extension's loadResource, so user-visible behavior is
+        // preserved. Re-add pre-flight once the parsers are added to
+        // the host's target membership in project.pbxproj.
 
         var imageURL: URL?
         var devNode: String?


### PR DESCRIPTION
PR #52's `TreeBuilder.parseAndBuild` call from `MountManager.swift` doesn't compile from a clean build — the host target's synced file group only covers `TestFS/`, and `TreeBuilder` / `JSONTree` / `TreeIndex` live in `TestFSExtension/`. My earlier "BUILD SUCCEEDED" was a stale-cache false positive that fell apart the moment I ran `scripts/install.sh` from a clean state.

## Effect on user-visible behavior

None. The marker channel (PR #53) catches the same failures via the extension's `loadResource` and short-circuits the 15s timeout. The only difference is one extra round-trip through `mount(8)` before the marker is written — measured in tens of ms, not seconds.

## Follow-up

Re-adding pre-flight properly needs one of:
- Add `TreeBuilder.swift` / `JSONTree.swift` / `TreeIndex.swift` to the host target's pbxproj membership (the same dual-membership pattern `MountOptions.swift` already uses).
- Move them to a `Shared/` directory synced into both targets.

Filing as a 0.1.17 follow-up. Not blocking 0.1.16.

## Verification

- `rm -rf build/derived && xcodebuild ... build`: `BUILD SUCCEEDED` from clean state.
- `swift test`: 98 tests pass.
- `swiftlint --strict`: 0 violations.