### PR TITLE
Re-add host-side pre-flight via host target membership

### DIFF
--- a/TestFS.xcodeproj/project.pbxproj
+++ b/TestFS.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		334796AE2CE227E9D72FA2D5 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = BE795F055376D8BD161A2D56 /* Sparkle */; };
+		A1B2C3D40000000000000001 /* TreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000101 /* TreeBuilder.swift */; };
+		A1B2C3D40000000000000002 /* JSONTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000102 /* JSONTree.swift */; };
+		A1B2C3D40000000000000003 /* TreeIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000103 /* TreeIndex.swift */; };
 		CC3283482D99D02200EFFA01 /* TestFSExtension.appex in Embed ExtensionKit Extensions */ = {isa = PBXBuildFile; fileRef = CC32833E2D99D02200EFFA01 /* TestFSExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		D6C092B22D1D8FACF1FCEF9E /* MountOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80534BA6D187E9CFE30D1A03 /* MountOptions.swift */; };
 /* End PBXBuildFile section */
@@ -39,6 +42,9 @@
 /* Begin PBXFileReference section */
 		118D8AF53DDD360633203624 /* com.sohonet.testfsmount.helperd.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist; name = com.sohonet.testfsmount.helperd.plist; path = TestFSHelper/com.sohonet.testfsmount.helperd.plist; sourceTree = "<group>"; };
 		80534BA6D187E9CFE30D1A03 /* MountOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MountOptions.swift; path = TestFSExtension/MountOptions.swift; sourceTree = "<group>"; };
+		A1B2C3D40000000000000101 /* TreeBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TreeBuilder.swift; path = TestFSExtension/TreeBuilder.swift; sourceTree = "<group>"; };
+		A1B2C3D40000000000000102 /* JSONTree.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JSONTree.swift; path = TestFSExtension/JSONTree.swift; sourceTree = "<group>"; };
+		A1B2C3D40000000000000103 /* TreeIndex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TreeIndex.swift; path = TestFSExtension/TreeIndex.swift; sourceTree = "<group>"; };
 		CC32833E2D99D02200EFFA01 /* TestFSExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = TestFSExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCF967EC2C1C110D00FBE72D /* TestFS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestFS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -111,6 +117,9 @@
 				CCF967ED2C1C110D00FBE72D /* Products */,
 				118D8AF53DDD360633203624 /* com.sohonet.testfsmount.helperd.plist */,
 				80534BA6D187E9CFE30D1A03 /* MountOptions.swift */,
+				A1B2C3D40000000000000101 /* TreeBuilder.swift */,
+				A1B2C3D40000000000000102 /* JSONTree.swift */,
+				A1B2C3D40000000000000103 /* TreeIndex.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -287,6 +296,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				D6C092B22D1D8FACF1FCEF9E /* MountOptions.swift in Sources */,
+				A1B2C3D40000000000000001 /* TreeBuilder.swift in Sources */,
+				A1B2C3D40000000000000002 /* JSONTree.swift in Sources */,
+				A1B2C3D40000000000000003 /* TreeIndex.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TestFS/MountManager.swift
+++ b/TestFS/MountManager.swift
@@ -45,14 +45,12 @@ actor MountManager {
     /// owns only the mount-specific `config` field (= staged tree
     /// path) and sidecar serialization.
     func prepareMount(treeJSON: Data, options: MountOptions) throws -> PrepareResult {
-        // NB: pre-flight `TreeBuilder.parseAndBuild` was removed —
-        // TestFSExtension's pure-Swift parsers aren't members of the
-        // host target, so the call doesn't compile from a clean
-        // build (PR #52 only worked through cached derived data).
-        // The marker channel (PR #53) catches the same failures via
-        // the extension's loadResource, so user-visible behavior is
-        // preserved. Re-add pre-flight once the parsers are added to
-        // the host's target membership in project.pbxproj.
+        // Pre-flight: surface JSON / TreeBuilder errors before
+        // allocating a dev node. The marker channel covers the same
+        // failures from the extension side, but pre-flight saves
+        // the round-trip and produces the same status text without
+        // mount(8) ever being involved.
+        _ = try TreeBuilder.parseAndBuild(treeJSON: treeJSON, options: options)
 
         var imageURL: URL?
         var devNode: String?

--- a/TestFSExtension/JSONTree.swift
+++ b/TestFSExtension/JSONTree.swift
@@ -2,10 +2,12 @@
 //  JSONTree.swift
 //  TestFSCore / TestFSExtension
 //
-//  Decoder for `tree -J -s` JSON output. Pure Swift, no FSKit imports,
-//  so it can be unit-tested via the SPM TestFSCore target while also
-//  being compiled into the Xcode FSKit extension target via the
-//  PBXFileSystemSynchronizedRootGroup.
+//  Decoder for `tree -J -s` JSON output.
+//
+//  Pure Swift — do NOT add `import FSKit` here. This file is
+//  dual-membership (TestFS host + TestFSExtension via pbxproj);
+//  FSKit isn't linked into the host target and an import would
+//  silently break the host build only on a clean rebuild.
 //
 
 import Foundation

--- a/TestFSExtension/TreeBuilder.swift
+++ b/TestFSExtension/TreeBuilder.swift
@@ -5,7 +5,12 @@
 //  Builds a TreeIndex from a parsed JSONTree node, assigning monotonic
 //  IDs, applying Unicode normalization from MountOptions, preserving
 //  insertion order for enumeration cookies, and failing loudly on
-//  case-insensitive name collisions. Pure Swift, no FSKit.
+//  case-insensitive name collisions.
+//
+//  Pure Swift — do NOT add `import FSKit` here. This file is
+//  dual-membership (TestFS host + TestFSExtension); FSKit isn't
+//  linked into the host target and an import would silently break
+//  the host build only on a clean pbxproj rebuild.
 //
 
 import Foundation

--- a/TestFSExtension/TreeIndex.swift
+++ b/TestFSExtension/TreeIndex.swift
@@ -2,13 +2,14 @@
 //  TreeIndex.swift
 //  TestFSCore / TestFSExtension
 //
-//  Pure-Swift representation of a parsed `tree -J -s` tree with stable
-//  monotonic IDs, preserved insertion order, and case-sensitive name
-//  lookup (matching the Python `jsonfs.py` upstream — see
-//  research/test_json_fs/jsonfs.py:_sanitize_path which never folds).
-//  TestFSVolume / TestFSItem (FSKit) wrap this at the next layer;
-//  TreeIndex itself has no FSKit dependency so it can be unit tested
-//  via `swift test`.
+//  Parsed `tree -J -s` tree with stable monotonic IDs, preserved
+//  insertion order, and case-sensitive name lookup (matching the
+//  Python `jsonfs.py` upstream).
+//
+//  Pure Swift — do NOT add `import FSKit` here. This file is
+//  dual-membership (TestFS host + TestFSExtension via pbxproj);
+//  FSKit isn't linked into the host target and an import would
+//  silently break the host build only on a clean rebuild.
 //
 
 import Foundation


### PR DESCRIPTION
Fixes #55.

PR #52's `TreeBuilder.parseAndBuild` call from `MountManager.prepareMount` was
reverted in #54 because the parsers (`TreeBuilder.swift`, `JSONTree.swift`,
`TreeIndex.swift`) weren't members of the host target — the host's synced root
group only covers `TestFS/`, and the parsers live in `TestFSExtension/`. Stale
DerivedData masked the failure during PR #52's CI; a clean rebuild surfaced it.

## Changes

- `TestFS.xcodeproj/project.pbxproj`: add the three parsers to the host target
  via dual-membership (PBXBuildFile + PBXFileReference + root-group children +
  PBXSourcesBuildPhase entries), mirroring the pattern `MountOptions.swift`
  already uses. The files stay synced into the extension target via its
  `PBXFileSystemSynchronizedRootGroup`.
- `TestFS/MountManager.swift`: re-add the `TreeBuilder.parseAndBuild` call at
  the top of `prepareMount`. Catches every host-decodable error
  (`BuildError.duplicateName`, `BuildError.totalSizeOverflow`,
  `JSONTree.LoadError`, ...) before any block-resource is allocated.
- `TestFSExtension/{TreeBuilder,JSONTree,TreeIndex}.swift`: header-comment
  warning for future maintainers — these files are dual-membership; adding
  `import FSKit` would silently break the host build only on a clean pbxproj
  rebuild.

The marker channel (PR #53) continues to cover FSKit-runtime errors that
pre-flight can't predict.

## Verification

- `swift test` — 98 tests pass.
- `swiftlint --strict` — 0 violations across 33 files.
- `xcodebuild ... build` from a clean `rm -rf build/derived` — succeeds (the
  PR #52 stale-cache regression is fixed).