### PR TITLE
mount.sh: route values through AppleScript quoted form, not shell interpolation

### DIFF
--- a/scripts/mount.sh
+++ b/scripts/mount.sh
@@ -82,7 +82,18 @@ fi
 # node, so mount -F under sudo would fail. osascript surfaces the
 # admin prompt as a GUI dialog so this works non-interactively from
 # outside a tty.
-osascript -e "do shell script \"chown $USER $DEV\" with administrator privileges" >/dev/null
+#
+# `$DEV` is read inside AppleScript via `system attribute`, then
+# `quoted form of` re-quotes it for the inner shell — keeps untrusted
+# bytes out of the AppleScript source text so they can't break into
+# `do shell script ... with administrator privileges`. Username comes
+# from `system info` (kernel credential) rather than the env, so a
+# tampered `USER` can't be a privesc primitive either.
+TESTFS_DEV="$DEV" osascript <<'APPLESCRIPT' >/dev/null
+set u to short user name of (system info)
+set dev to system attribute "TESTFS_DEV"
+do shell script "/usr/sbin/chown " & quoted form of u & " " & quoted form of dev with administrator privileges
+APPLESCRIPT
 
 BSD="${DEV#/dev/}"
 echo "Allocated $DEV (image $IMG, bsdName=$BSD)"


### PR DESCRIPTION
Fixes #57.

The previous form built the privileged shell command via Bash
interpolation:

```bash
osascript -e "do shell script \"chown $USER $DEV\" with administrator privileges"
```

`$USER` is environment-controlled, so a tampered value
(`USER='ben; touch /tmp/PWNED'`) injected arbitrary commands into the
inner shell, executed as root once the operator approved the standard
mount-time password prompt — a local privilege-escalation primitive.

## Fix

- Username: read from `short user name of (system info)` inside
  AppleScript. That uses the kernel credential, not `$USER`, so a
  tampered env can't influence it.
- Device path: passed via env (`TESTFS_DEV`), read inside AppleScript
  via `system attribute`, then re-quoted for the inner shell with
  `quoted form of`. Untrusted bytes never appear in the AppleScript
  source text, so they can't escape into either AppleScript or shell
  context.

## Verified

Confirmed `quoted form of` wraps malicious payloads safely:

```
$ FOO='bob"; rm -rf /' osascript <<'AS'
> set u to system attribute "FOO"
> return quoted form of u
> AS
'bob"; rm -rf /'
```

(Single-quoted shell string — no escape into root command.)

Confirmed `short user name of (system info)` returns the expected
username (`ben`) with no env dependency.

`bash -n scripts/mount.sh` clean. `swift test` (98 tests) and
`swiftlint --strict` (33 files) green.

## Out of scope

No other osascript / `do shell script` / `with administrator
privileges` call sites exist in the repo (verified across
`TestFS/`, `TestFSExtension/`, and `scripts/`). No shared helper to
extract.