### PR TITLE
runSilently: SIGKILL escalation, share helper with ShellRunner

### DIFF
--- a/TestFS/ContentView+Helpers.swift
+++ b/TestFS/ContentView+Helpers.swift
@@ -90,10 +90,11 @@ enum AppEnvironment {
             return false
         }
         if done.wait(timeout: .now() + subprocessTimeout) == .timedOut {
-            // SIGTERM the wedged child so the actor can move on. The
-            // termination handler will eventually fire as the process
-            // exits, but we don't wait for it.
-            proc.terminate()
+            // A child that traps SIGTERM (or is stuck in uninterruptible
+            // I/O) would survive a bare terminate(), letting a later
+            // retry stack overlapping pluginkit / lsregister processes
+            // against the same registration.
+            ShellRunner.terminate(proc, exitSem: done)
             return false
         }
         return proc.terminationStatus == 0

--- a/TestFS/ShellRunner.swift
+++ b/TestFS/ShellRunner.swift
@@ -25,6 +25,28 @@ enum ShellRunner {
     /// fail loud rather than block its actor.
     static let defaultTimeout: TimeInterval = 30.0
 
+    /// Window after SIGTERM before escalating to SIGKILL. A child that
+    /// traps SIGTERM (or is in uninterruptible I/O) needs the kill;
+    /// 2s is enough for a cooperative child to finish writing logs.
+    private static let sigtermGrace: TimeInterval = 2.0
+    /// Window after SIGKILL before giving up on reaping. The kernel
+    /// delivers SIGKILL synchronously; 1s is generous for the
+    /// terminationHandler to fire.
+    private static let sigkillGrace: TimeInterval = 1.0
+
+    /// Bounded SIGTERM → SIGKILL escalation for a wedged child.
+    /// `exitSem` must be the semaphore signalled from the process's
+    /// `terminationHandler`. Returns when the process is reaped or the
+    /// SIGKILL grace window expires; the caller decides what to do
+    /// with that outcome (most callers return a failure result).
+    static func terminate(_ proc: Process, exitSem: DispatchSemaphore) {
+        proc.terminate()
+        if exitSem.wait(timeout: .now() + sigtermGrace) == .timedOut {
+            kill(proc.processIdentifier, SIGKILL)
+            _ = exitSem.wait(timeout: .now() + sigkillGrace)
+        }
+    }
+
     static func run(
         _ path: String,
         _ args: [String],
@@ -54,17 +76,11 @@ enum ShellRunner {
             group.leave()
         }
         if exitSem.wait(timeout: .now() + timeout) == .timedOut {
-            // SIGTERM first; if the child traps it (or is stuck in
-            // uninterruptible I/O), the pipes stay open and the drain
-            // reads block forever — defeating the timeout. Escalate
-            // to SIGKILL after 2s, then bound the drain wait so
-            // group.wait can't itself hang.
-            proc.terminate()
-            if exitSem.wait(timeout: .now() + 2.0) == .timedOut {
-                kill(proc.processIdentifier, SIGKILL)
-                _ = exitSem.wait(timeout: .now() + 1.0)
-            }
-            _ = group.wait(timeout: .now() + 1.0)
+            // Bound the drain wait after escalation so group.wait
+            // can't itself hang on a pipe whose write end never
+            // closed (uninterruptible I/O hold).
+            Self.terminate(proc, exitSem: exitSem)
+            _ = group.wait(timeout: .now() + sigkillGrace)
             return Result(
                 exit: -1,
                 stdout: String(data: outData, encoding: .utf8) ?? "",


### PR DESCRIPTION
Fixes #58.

`runSilently` previously SIGTERMed and returned immediately. A child
that traps SIGTERM (or is stuck in uninterruptible I/O) survived:
`ExtensionReregistration` cleared its cached task on failure and the
next mount click spawned another copy, stacking overlapping
`lsregister` / `pluginkit` processes against the same registration.

The same SIGTERM→SIGKILL shape was already in `ShellRunner.run` (#42).
Two near-duplicate copies were a known follow-up; round-4 audit
promoted the drift to a bug.

## Fix

- New `ShellRunner.terminate(_:exitSem:)` helper owns the bounded
  SIGTERM → wait → SIGKILL → wait sequence with named graces
  (`sigtermGrace`, `sigkillGrace`).
- `ShellRunner.run` and `runSilently` both call it. The drain wait
  in `ShellRunner.run` reuses `sigkillGrace` for consistency.
- `runSilently` keeps `FileHandle.nullDevice` (no pipe drain), so it
  doesn't need the post-escalation `group.wait` that `ShellRunner.run`
  has — the divergence is now structural rather than accidental.

## Verified

- `swift test`: 98 tests pass.
- `swiftlint --strict`: 0 violations.
- `xcodebuild ... build`: succeeds.
- Worst-case wait per timed-out subprocess: 5s (existing budget) +
  2s (sigtermGrace) + 1s (sigkillGrace) = 8s. Across the four
  re-registration commands that's 32s in the absolute worst case;
  happy path is unchanged.

## Out of scope

Folding `runSilently` entirely into `ShellRunner.run` would route the
discard-output calls through two pipes + a drain queue per call,
regressing the four sequential calls in `performReregisterIfNeeded`.
The shared escalation helper is the right level of unification.