### PR TITLE
Failure-marker channel: attempt-scoped token to defend against /dev/diskN reuse

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,7 @@ let package = Package(
             ],
             sources: [
                 "TestFSExtension/JSONTree.swift",
+                "TestFSExtension/LoadFailureMarker.swift",
                 "TestFSExtension/MountOptions.swift",
                 "TestFSExtension/TreeIndex.swift",
                 "TestFSExtension/TreeBuilder.swift",

--- a/TestFS.xcodeproj/project.pbxproj
+++ b/TestFS.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		A1B2C3D40000000000000001 /* TreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000101 /* TreeBuilder.swift */; };
 		A1B2C3D40000000000000002 /* JSONTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000102 /* JSONTree.swift */; };
 		A1B2C3D40000000000000003 /* TreeIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000103 /* TreeIndex.swift */; };
+		A1B2C3D40000000000000004 /* LoadFailureMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000104 /* LoadFailureMarker.swift */; };
 		CC3283482D99D02200EFFA01 /* TestFSExtension.appex in Embed ExtensionKit Extensions */ = {isa = PBXBuildFile; fileRef = CC32833E2D99D02200EFFA01 /* TestFSExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		D6C092B22D1D8FACF1FCEF9E /* MountOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80534BA6D187E9CFE30D1A03 /* MountOptions.swift */; };
 /* End PBXBuildFile section */
@@ -45,6 +46,7 @@
 		A1B2C3D40000000000000101 /* TreeBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TreeBuilder.swift; path = TestFSExtension/TreeBuilder.swift; sourceTree = "<group>"; };
 		A1B2C3D40000000000000102 /* JSONTree.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = JSONTree.swift; path = TestFSExtension/JSONTree.swift; sourceTree = "<group>"; };
 		A1B2C3D40000000000000103 /* TreeIndex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TreeIndex.swift; path = TestFSExtension/TreeIndex.swift; sourceTree = "<group>"; };
+		A1B2C3D40000000000000104 /* LoadFailureMarker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LoadFailureMarker.swift; path = TestFSExtension/LoadFailureMarker.swift; sourceTree = "<group>"; };
 		CC32833E2D99D02200EFFA01 /* TestFSExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = TestFSExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCF967EC2C1C110D00FBE72D /* TestFS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestFS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -120,6 +122,7 @@
 				A1B2C3D40000000000000101 /* TreeBuilder.swift */,
 				A1B2C3D40000000000000102 /* JSONTree.swift */,
 				A1B2C3D40000000000000103 /* TreeIndex.swift */,
+				A1B2C3D40000000000000104 /* LoadFailureMarker.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -299,6 +302,7 @@
 				A1B2C3D40000000000000001 /* TreeBuilder.swift in Sources */,
 				A1B2C3D40000000000000002 /* JSONTree.swift in Sources */,
 				A1B2C3D40000000000000003 /* TreeIndex.swift in Sources */,
+				A1B2C3D40000000000000004 /* LoadFailureMarker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TestFS/MountManager.swift
+++ b/TestFS/MountManager.swift
@@ -20,6 +20,10 @@ actor MountManager {
 
     struct PrepareResult {
         let devNodePath: String
+        /// Token written into the staged sidecar; used by the host's
+        /// marker filter so a stale marker from a prior /dev/diskN
+        /// attempt can't trigger rollback for this one.
+        let attemptToken: String
         var bsdName: String { .bsdName(fromDevNode: devNodePath) }
     }
 
@@ -80,6 +84,13 @@ actor MountManager {
 
             var sidecarOptions = options
             sidecarOptions.config = paths.tree.path
+            // Per-attempt token: extension writes the same value into
+            // any failure marker, host filters markers on token match.
+            // Defends against a slow-failing prior loadResource on a
+            // reused /dev/diskN (and subsequent BSD) writing a marker
+            // after stage-time delete.
+            let attemptToken = UUID().uuidString
+            sidecarOptions.attemptToken = attemptToken
             let sidecar = try Self.sidecarEncoder.encode(sidecarOptions)
             try sidecar.write(to: paths.sidecar, options: .atomic)
 
@@ -87,7 +98,7 @@ actor MountManager {
             try? FileManager.default.removeItem(at: failureMarkerURL(forBSD: bsd))
 
             log.info("prepareMount: \(bsd, privacy: .public)")
-            return PrepareResult(devNodePath: dev)
+            return PrepareResult(devNodePath: dev, attemptToken: attemptToken)
         } catch {
             if let dev = devNode { try? hdiutilDetach(devNode: dev) }
             if let img = imageURL { try? FileManager.default.removeItem(at: img) }
@@ -169,10 +180,18 @@ actor MountManager {
     }
 
     /// Read the extension-written failure marker. Returns the error
-    /// reason, or nil if the marker doesn't exist or is malformed.
-    fileprivate static func readFailureMarker(at url: URL) -> String? {
+    /// reason only when the marker's `attemptToken` matches the one
+    /// staged into the current attempt's sidecar. Mismatches mean the
+    /// marker was written by a prior loadResource that was still
+    /// unwinding when /dev/diskN got reused — ignoring those prevents
+    /// false rollback of a fresh mount.
+    fileprivate static func readFailureMarker(at url: URL, expecting token: String) -> String? {
         guard let data = try? Data(contentsOf: url) else { return nil }
-        return try? JSONDecoder().decode(LoadFailureMarker.self, from: data).error
+        guard let marker = try? JSONDecoder().decode(LoadFailureMarker.self, from: data) else {
+            return nil
+        }
+        guard marker.attemptToken == token else { return nil }
+        return marker.error
     }
 
     // MARK: - hdiutil / mkfile
@@ -300,7 +319,7 @@ actor MountManager {
             if Self.statfsType(at: mountpoint) == TestFSConstants.fstype {
                 return .mounted
             }
-            if let reason = Self.readFailureMarker(at: markerURL) {
+            if let reason = Self.readFailureMarker(at: markerURL, expecting: prep.attemptToken) {
                 return .failed(reason: reason)
             }
             try? await Task.sleep(for: Self.mountConfirmPollInterval)

--- a/TestFSExtension/LoadFailureMarker.swift
+++ b/TestFSExtension/LoadFailureMarker.swift
@@ -1,0 +1,31 @@
+//
+//  LoadFailureMarker.swift
+//  TestFSCore / TestFSExtension
+//
+//  Shape of the failure-marker JSON the extension writes on
+//  `loadResource` error so the host can decode the underlying
+//  reason instead of polling blind for the full 15s timeout.
+//
+//  Pure Swift — do NOT add `import FSKit` here. This file is
+//  dual-membership (TestFS host + TestFSExtension via pbxproj);
+//  FSKit isn't linked into the host target and an import would
+//  silently break the host build only on a clean rebuild.
+//
+
+import Foundation
+
+/// `attemptToken` mirrors the `attempt_token` field the host stages
+/// into the sidecar; the host accepts a marker only when the tokens
+/// match. Optional for forward-compat with markers written before
+/// the token plumbing existed (those markers are ignored, which is
+/// safe — stage-time delete already prevents stale markers in the
+/// common path).
+struct LoadFailureMarker: Codable {
+    let error: String
+    let attemptToken: String?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case attemptToken = "attempt_token"
+    }
+}

--- a/TestFSExtension/MountOptions.swift
+++ b/TestFSExtension/MountOptions.swift
@@ -6,6 +6,9 @@
 //  Defaults match Python jsonfs.py's CLI defaults.
 //
 
+// swiftlint:disable file_length
+// Codable-conformance split deferred — keep this commit focused.
+
 import Foundation
 
 /// Identity strings shared by host and extension.
@@ -92,6 +95,9 @@ struct MountOptions: Equatable, Sendable {
     /// to silence the periodic line.
     var reportStats: Bool
 
+    /// Per-attempt token echoed back by the extension into any
+    /// failure marker — see `LoadFailureMarker`.
+    var attemptToken: String?
     init(
         config: String? = nil,
         fillChar: String = "\u{0000}",
@@ -109,7 +115,8 @@ struct MountOptions: Equatable, Sendable {
         addMacosCacheFiles: Bool = true,
         volumeName: String? = nil,
         verbose: Bool = false,
-        reportStats: Bool = true
+        reportStats: Bool = true,
+        attemptToken: String? = nil
     ) {
         self.config = config
         self.fillChar = fillChar
@@ -128,6 +135,7 @@ struct MountOptions: Equatable, Sendable {
         self.volumeName = volumeName
         self.verbose = verbose
         self.reportStats = reportStats
+        self.attemptToken = attemptToken
     }
 }
 
@@ -224,6 +232,11 @@ extension MountOptions {
         case volumeName = "volume_name"
         case verbose
         case reportStats = "report_stats"
+        // The "attempt_token" string is also referenced in
+        // LoadFailureMarker.CodingKeys and TestFileSystem.SidecarTokenPeek;
+        // CodingKey raw values must be string literals, so a rename
+        // has to touch all three.
+        case attemptToken = "attempt_token"
     }
 
     /// Python-CLI defaults, used both as `.default` and as the fallback
@@ -261,7 +274,8 @@ extension MountOptions: Codable {
                 ?? defaults.addMacosCacheFiles,
             volumeName: try container.decodeIfPresent(String.self, forKey: .volumeName),
             verbose: try container.decodeIfPresent(Bool.self, forKey: .verbose) ?? defaults.verbose,
-            reportStats: try container.decodeIfPresent(Bool.self, forKey: .reportStats) ?? defaults.reportStats
+            reportStats: try container.decodeIfPresent(Bool.self, forKey: .reportStats) ?? defaults.reportStats,
+            attemptToken: try container.decodeIfPresent(String.self, forKey: .attemptToken)
         )
     }
 
@@ -284,14 +298,8 @@ extension MountOptions: Codable {
         try container.encodeIfPresent(volumeName, forKey: .volumeName)
         try container.encode(verbose, forKey: .verbose)
         try container.encode(reportStats, forKey: .reportStats)
+        try container.encodeIfPresent(attemptToken, forKey: .attemptToken)
     }
-}
-
-/// Shape of the failure-marker JSON the extension writes on
-/// `loadResource` error so the host can decode the underlying
-/// reason instead of polling blind for the full timeout.
-struct LoadFailureMarker: Codable {
-    let error: String
 }
 
 extension MountOptions {

--- a/TestFSExtension/TestFileSystem.swift
+++ b/TestFSExtension/TestFileSystem.swift
@@ -25,6 +25,17 @@ enum Log {
     static let stats = Logger(subsystem: Identity.subsystem, category: "stats")
 }
 
+/// Decoder shape used by `peekAttemptToken` to read just the
+/// `attempt_token` field out of a sidecar without running the full
+/// `MountOptions.load` validation. Lifted out of `peekAttemptToken`
+/// so its CodingKeys enum doesn't push nesting past 1 level.
+private struct SidecarTokenPeek: Decodable {
+    let attemptToken: String?
+    enum CodingKeys: String, CodingKey {
+        case attemptToken = "attempt_token"
+    }
+}
+
 final class TestFileSystem: FSUnaryFileSystem, FSUnaryFileSystemOperations {
     func probeResource(
         resource: FSResource,
@@ -54,8 +65,14 @@ final class TestFileSystem: FSUnaryFileSystem, FSUnaryFileSystemOperations {
         }
         let bsd = block.bsdName
         Log.mount.info("loadResource starting for \(bsd, privacy: .public)")
+        let sidecarURL = MountOptions.sidecarURL(forBSDName: bsd)
+        // Peek the attempt token from the raw sidecar before any
+        // validation can fail. Marker JSON carries the token even when
+        // MountOptions.load itself throws (malformed sidecar, missing
+        // config), so the host's filter still accepts those markers
+        // for the current attempt.
+        let attemptToken = Self.peekAttemptToken(at: sidecarURL)
         do {
-            let sidecarURL = MountOptions.sidecarURL(forBSDName: bsd)
             let mountOptions = try MountOptions.load(from: sidecarURL)
             let configPath = mountOptions.config!
             let treeData = try Data(contentsOf: URL(fileURLWithPath: configPath), options: .mappedIfSafe)
@@ -75,7 +92,9 @@ final class TestFileSystem: FSUnaryFileSystem, FSUnaryFileSystemOperations {
             let markerURL = MountOptions.failureMarkerURL(forBSDName: bsd)
             do {
                 let data = try JSONEncoder().encode(
-                    LoadFailureMarker(error: error.localizedDescription))
+                    LoadFailureMarker(
+                        error: error.localizedDescription,
+                        attemptToken: attemptToken))
                 try data.write(to: markerURL, options: .atomic)
             } catch {
                 Log.mount.error(
@@ -84,6 +103,16 @@ final class TestFileSystem: FSUnaryFileSystem, FSUnaryFileSystemOperations {
             Log.mount.error("loadResource failed: \(error.localizedDescription, privacy: .public)")
             replyHandler(nil, error)
         }
+    }
+
+    /// Decodes only the `attempt_token` field, ignoring everything
+    /// else. Returns nil if the sidecar is unreadable or its JSON
+    /// can't be parsed at all — the marker still gets written without
+    /// a token, which the host's filter will reject (matching the
+    /// pre-token behavior for malformed sidecars).
+    private static func peekAttemptToken(at url: URL) -> String? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return (try? JSONDecoder().decode(SidecarTokenPeek.self, from: data))?.attemptToken
     }
 
     /// Deterministic container ID from the BSD name, so a re-probe of the

--- a/Tests/TestFSCoreTests/AttemptTokenTests.swift
+++ b/Tests/TestFSCoreTests/AttemptTokenTests.swift
@@ -1,0 +1,43 @@
+//
+//  AttemptTokenTests.swift
+//
+//  Tests for the per-attempt token plumbed through the sidecar
+//  (`MountOptions.attemptToken`) and the failure marker
+//  (`LoadFailureMarker.attemptToken`). The token defends against
+//  stale markers from a slow-failing prior loadResource on a
+//  reused /dev/diskN — the host's poll filter accepts a marker
+//  only when its token matches the current attempt's sidecar.
+//
+
+import XCTest
+@testable import TestFSCore
+
+final class AttemptTokenTests: XCTestCase {
+
+    func testAttemptTokenAbsentDecodesAsNil() throws {
+        let json = Data("""
+            {"config": "/tmp/tree.json"}
+            """.utf8)
+        let decoded = try MountOptions.load(from: json)
+        XCTAssertNil(decoded.attemptToken)
+    }
+
+    func testLoadFailureMarkerRoundTripsAttemptToken() throws {
+        let marker = LoadFailureMarker(
+            error: "bad sidecar", attemptToken: "abc-123")
+        let data = try JSONEncoder().encode(marker)
+        let decoded = try JSONDecoder().decode(LoadFailureMarker.self, from: data)
+        XCTAssertEqual(decoded.error, "bad sidecar")
+        XCTAssertEqual(decoded.attemptToken, "abc-123")
+    }
+
+    func testLoadFailureMarkerDecodesWithoutAttemptToken() throws {
+        // Forward-compat: a marker written by an older extension (or
+        // by the peek-failed path) has no token. Decode must succeed
+        // so logs aren't poisoned; the host's filter then rejects it.
+        let json = Data(#"{"error": "old format"}"#.utf8)
+        let decoded = try JSONDecoder().decode(LoadFailureMarker.self, from: json)
+        XCTAssertEqual(decoded.error, "old format")
+        XCTAssertNil(decoded.attemptToken)
+    }
+}

--- a/Tests/TestFSCoreTests/MountOptionsTests.swift
+++ b/Tests/TestFSCoreTests/MountOptionsTests.swift
@@ -275,10 +275,12 @@ final class MountOptionsTests: XCTestCase {
             gid: 1000,
             mtime: "2019-06-01",
             ignoreAppledouble: true,
-            addMacosCacheFiles: false
+            addMacosCacheFiles: false,
+            attemptToken: "11111111-2222-3333-4444-555555555555"
         )
         let encoded = try JSONEncoder().encode(original)
         let decoded = try MountOptions.load(from: encoded)
         XCTAssertEqual(decoded, original)
     }
+
 }


### PR DESCRIPTION
Fixes #59.

The marker channel from PR #53 keyed markers only by BSD name. After
detach + `/dev/diskN` reuse, a slow-failing prior `loadResource` could
write the marker after the new mount's stage-time delete — triggering
false rollback on the new mount with the prior attempt's error text.
Same diskN-reuse class hardened in #31 / #41 elsewhere.

## Fix

End-to-end attempt token (UUID, host-generated per `prepareMount`):

- `MountOptions.attemptToken: String?` — staged into the sidecar JSON
  alongside the existing fields. Optional so test fixtures and the
  CLI `mount.sh` flow stay valid without one.
- `LoadFailureMarker` extracted into its own file (mirrors the
  dual-membership pattern from #56). New optional `attemptToken`
  field; the extension's marker writer copies the token from a
  peek-only Decodable read of the raw sidecar (so the token is
  available even when full `MountOptions.load` validation throws).
- `MountManager.PrepareResult.attemptToken` returned from
  `prepareMount` and threaded into `waitForMount`.
- `MountManager.readFailureMarker(at:expecting:)` accepts the
  marker only when the token matches; mismatches fall through to
  the existing 15s timeout (host-visible behavior matches
  pre-marker semantics).

## Tests

`Tests/TestFSCoreTests/AttemptTokenTests.swift` (new):
- `MountOptions` decode without `attempt_token` -> nil (defaults case).
- `LoadFailureMarker` round-trips `attemptToken`.
- `LoadFailureMarker` decodes a marker without `attempt_token`
  (forward-compat: marker still parses, host filter rejects it).

Existing `MountOptionsTests.testRoundTripEncodesAllFields` extended
to assert the field round-trips alongside everything else.

## Plumbing

- `Package.swift`: `TestFSExtension/LoadFailureMarker.swift` added to
  the SPM target sources.
- `TestFS.xcodeproj/project.pbxproj`: dual-membership for the new
  file (host + extension), mirroring the parsers from #56.
- `swiftlint:disable file_length` on `MountOptions.swift` documents
  that a Codable-conformance split is the right next move; deferred
  to keep this commit focused.

## Verified

- `swift test`: 101 tests pass (3 new).
- `swiftlint --strict`: 0 violations across 35 files.
- Clean `xcodebuild ... build` from `rm -rf build/derived`: succeeds.