### PR TITLE
MountManager.prepareMount: run pre-flight TreeBuilder off-actor

### DIFF
--- a/TestFS/MountManager.swift
+++ b/TestFS/MountManager.swift
@@ -48,13 +48,14 @@ actor MountManager {
     /// needs. Caller passes a pre-built `MountOptions`; this method
     /// owns only the mount-specific `config` field (= staged tree
     /// path) and sidecar serialization.
-    func prepareMount(treeJSON: Data, options: MountOptions) throws -> PrepareResult {
-        // Pre-flight: surface JSON / TreeBuilder errors before
-        // allocating a dev node. The marker channel covers the same
-        // failures from the extension side, but pre-flight saves
-        // the round-trip and produces the same status text without
-        // mount(8) ever being involved.
-        _ = try TreeBuilder.parseAndBuild(treeJSON: treeJSON, options: options)
+    func prepareMount(treeJSON: Data, options: MountOptions) async throws -> PrepareResult {
+        // Pre-flight runs off-actor so a large fixture's parse / build
+        // doesn't block concurrent unmounts, sweep, or registry
+        // refresh on this actor. parseAndBuild is pure, so a detached
+        // task is safe.
+        try await Task.detached(priority: .userInitiated) {
+            _ = try TreeBuilder.parseAndBuild(treeJSON: treeJSON, options: options)
+        }.value
 
         var imageURL: URL?
         var devNode: String?


### PR DESCRIPTION
Fixes #60.

The pre-flight `TreeBuilder.parseAndBuild` re-added in PR #56 ran
synchronously on the `MountManager` actor. Typical fixtures parse in
milliseconds, but a large tree JSON (tens of MB, hundreds of
thousands of nodes) could pin the actor for hundreds of milliseconds
to seconds — blocking concurrent unmounts, sweep cleanup, and
registry refresh while the parse work proceeds.

## Fix

Wrap `parseAndBuild` in `Task.detached(priority: .userInitiated)` and
await its result before staging. `parseAndBuild` is pure (no
shared/actor state, no FSKit calls), so a detached task is safe.

The function signature changes from `throws` to `async throws`. The
single caller (`ContentView.mountSelected`) already used `try await`
for the cross-actor implicit await — so no call-site changes.

## Verified

- `swift test`: 101 tests pass.
- `swiftlint --strict`: 0 violations across 35 files.
- `xcodebuild ... build`: succeeds, no new warnings.

## Out of scope (follow-up)

The reuse-review surfaced that other shell-out call sites in
`MountManager` (`createSparseImage`, `hdiutilAttach`, `hdiutilDetach`,
`mount`, `unmount`, `attachedImagePaths`) also block the actor for
the duration of `ShellRunner.run`. They have the same actor-blocking
class as the pre-flight parse, but each has its own concurrency
contract that needs a deeper look — left for a separate change.