### PR TITLE
Sparkle pre-install: abort update if testfs mounts can't be unmounted

### DIFF
--- a/TestFS/ContentView.swift
+++ b/TestFS/ContentView.swift
@@ -278,23 +278,15 @@ struct ContentView: View {
     private func unmount(_ record: MountRecord) async {
         busy = true; defer { busy = false }
         status = "unmounting \(record.mountpoint)…"
-        do {
-            try await MountManager.shared.unmount(at: record.mountpoint)
-        } catch {
+        switch await MountManager.shared.unmountAndForget(record) {
+        case .ok:
+            status = "unmounted \(record.mountpoint)"
+        case .umountFailed(let error):
             status = "umount failed: \(error.localizedDescription)"
-            return
-        }
-        do {
-            try await MountManager.shared.detach(bsdName: record.bsdName)
-        } catch {
+        case .detachFailed(let error):
             status = "unmounted, but detach failed: \(error.localizedDescription)"
-            await MountRegistry.shared.forget(bsdName: record.bsdName)
-            mounts = await MountRegistry.shared.snapshot()
-            return
         }
-        await MountRegistry.shared.forget(bsdName: record.bsdName)
         mounts = await MountRegistry.shared.snapshot()
-        status = "unmounted \(record.mountpoint)"
     }
 
     private func refresh() async {

--- a/TestFS/MountManager+Sweep.swift
+++ b/TestFS/MountManager+Sweep.swift
@@ -1,0 +1,48 @@
+//
+//  MountManager+Sweep.swift
+//  TestFS
+//
+//  Shared umount → detach → forget helper used by both the user's
+//  per-row unmount click (`ContentView.unmount`) and the Sparkle
+//  pre-install hook (`TestFSUpdaterDelegate.unmountAllForUpdate`).
+//  Living in its own file keeps `MountManager.swift` under the
+//  file-length budget.
+//
+
+import Foundation
+
+extension MountManager {
+    /// Outcome of a single `unmountAndForget` call. `.detachFailed`
+    /// means the volume is no longer mounted (so the kernel no longer
+    /// pins the FSKit appex), but the backing dev node is still
+    /// attached — caller should treat it as a soft failure.
+    enum UnmountOutcome {
+        // swiftlint:disable:next identifier_name
+        case ok
+        case umountFailed(Error)
+        case detachFailed(Error)
+    }
+
+    /// Run umount → detach → forget for a single mount record. Always
+    /// invokes `MountRegistry.forget` once umount succeeds, even if
+    /// detach later fails: the kernel no longer holds the volume, so
+    /// the registry must stop claiming it does.
+    func unmountAndForget(_ record: MountRecord) async -> UnmountOutcome {
+        do {
+            try unmount(at: record.mountpoint)
+        } catch {
+            return .umountFailed(error)
+        }
+        var detachError: Error?
+        do {
+            try detach(bsdName: record.bsdName)
+        } catch {
+            detachError = error
+        }
+        await MountRegistry.shared.forget(bsdName: record.bsdName)
+        if let detachError {
+            return .detachFailed(detachError)
+        }
+        return .ok
+    }
+}

--- a/TestFS/TestFSApp.swift
+++ b/TestFS/TestFSApp.swift
@@ -6,6 +6,7 @@
 //
 
 import AppKit
+import OSLog
 import Sparkle
 import SwiftUI
 
@@ -24,16 +25,122 @@ extension Notification.Name {
     static let testFSPickExample = Notification.Name("TestFSPickExample")
 }
 
+/// Sparkle delegate that unmounts every live testfs volume before
+/// allowing the bundle replace. An active mount keeps the FSKit
+/// appex pinned in the kernel — without this gate, Sparkle would
+/// proceed and the bundle replace would fail silently, leaving the
+/// user on a stale install. If unmount-all fails for any volume we
+/// abort the install loudly via an alert, so the user can clean up
+/// and retry instead of ending up half-updated. See #65.
+final class TestFSUpdaterDelegate: NSObject, SPUUpdaterDelegate {
+    private let log = Logger(subsystem: TestFSConstants.logSubsystem, category: "sparkle")
+
+    /// Hard ceiling on the precheck. ShellRunner's per-call timeout
+    /// already bounds individual umount/detach waits, but a long
+    /// list of mounts (each requiring two ShellRunner calls) could
+    /// otherwise stretch past a reasonable user-visible budget.
+    /// Past this point we abort with the same loud-failure alert as
+    /// any other cleanup failure.
+    private static let precheckBudget: Duration = .seconds(60)
+
+    /// Defer Sparkle's install until our async cleanup finishes. Any
+    /// failure (umount error or budget timeout) aborts the install —
+    /// we never call `immediateInstallationBlock`, Sparkle keeps the
+    /// downloaded update queued, and the user gets an alert telling
+    /// them to clean up and retry.
+    func updater(
+        _ updater: SPUUpdater,
+        willInstallUpdateOnQuit item: SUAppcastItem,
+        immediateInstallationBlock: @escaping () -> Void
+    ) -> Bool {
+        Task { @MainActor in
+            let succeeded = await Self.unmountAllForUpdate(
+                log: log, budget: Self.precheckBudget)
+            if succeeded {
+                immediateInstallationBlock()
+            } else {
+                Self.showAbortAlert()
+            }
+        }
+        return true
+    }
+
+    /// Iterate the live mount list and run `unmountAndForget` per
+    /// record. `.detachFailed` is *not* a fatal precheck error: the
+    /// kernel has already released the appex by then, so the install
+    /// can proceed; the leftover dev node will be swept on next
+    /// launch. Cancellation (from the budget watchdog) is checked
+    /// between mounts so a wedged sweep can't outlive its budget by
+    /// more than the currently-running ShellRunner call.
+    private static func unmountAllForUpdate(log: Logger, budget: Duration) async -> Bool {
+        let cleanup = Task { () -> Bool in
+            let mounts = await MountRegistry.shared.refreshed()
+            guard !mounts.isEmpty else {
+                log.info("update precheck: no live testfs mounts")
+                return true
+            }
+            log.info("update precheck: \(mounts.count, privacy: .public) live mount(s) to sweep")
+            var allOK = true
+            for record in mounts {
+                guard !Task.isCancelled else { return false }
+                switch await MountManager.shared.unmountAndForget(record) {
+                case .ok:
+                    continue
+                case .umountFailed(let error):
+                    let msg = error.localizedDescription
+                    log.error("umount \(record.mountpoint, privacy: .public) failed: \(msg, privacy: .public)")
+                    allOK = false
+                case .detachFailed(let error):
+                    let msg = error.localizedDescription
+                    let bsd = record.bsdName
+                    log.warning(
+                        "detach \(bsd, privacy: .public) failed (umount ok): \(msg, privacy: .public)")
+                }
+            }
+            return allOK
+        }
+        let watchdog = Task {
+            try? await Task.sleep(for: budget)
+            cleanup.cancel()
+        }
+        let result = await cleanup.value
+        watchdog.cancel()
+        return result
+    }
+
+    @MainActor
+    private static func showAbortAlert() {
+        let alert = NSAlert()
+        alert.messageText = "TestFS update aborted"
+        alert.informativeText =
+            "One or more testfs volumes could not be cleanly "
+            + "unmounted. The kernel still has the previous "
+            + "extension pinned, so installing now would leave "
+            + "TestFS half-updated. Unmount the affected volumes "
+            + "manually, then choose Check for Updates… again."
+        alert.alertStyle = .warning
+        alert.runModal()
+    }
+}
+
 @main
 struct TestFSApp: App {
+    /// Sparkle delegate that runs unmount-all before the update's
+    /// quit-to-relaunch. Held by the App for the process lifetime so
+    /// SPUStandardUpdaterController's weak reference stays valid.
+    private let updaterDelegate = TestFSUpdaterDelegate()
+
     /// Sparkle's standard updater. Held by the App so it lives
     /// for the process lifetime; `startingUpdater: true` performs
     /// the auto-check on launch governed by `SUEnableAutomaticChecks`
     /// in Info.plist.
-    private let updaterController = SPUStandardUpdaterController(
-        startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
+    private let updaterController: SPUStandardUpdaterController
 
     init() {
+        self.updaterController = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: updaterDelegate,
+            userDriverDelegate: nil)
         // Composite the ladybug onto the dock + About-box icon. In
         // Release it's solid black; in Debug it's solid red so a dev
         // build stands out from a shipped one at a glance.


### PR DESCRIPTION
Fixes #65.

An active testfs mount keeps the FSKit appex pinned in the kernel.
Without a pre-install hook, Sparkle's bundle replace fails silently
on quit — the user sees the new version in About box but
`/Applications/TestFS.app` stays on the old version, plus
LaunchServices accumulates stale registrations from each attempted
install. Repro: TestFS 0.1.15 → Check for Updates → 0.1.17, machine
ends up with About showing 0.1.17 but disk at 0.1.15 and 24 stale
lsregister entries.

## Fix

`SPUUpdaterDelegate.updater(_:willInstallUpdateOnQuit:
immediateInstallationBlock:)` returns `true` to claim the install
trigger, then runs an async unmount sweep. Behavior is binary:

- All-clean → invoke `immediateInstallationBlock()`. Sparkle proceeds
  with the normal quit + replace + relaunch sequence.
- Any failure → never call the block. Show NSAlert ("kernel still
  has the previous extension pinned … unmount manually then check
  for updates again"). Sparkle keeps the downloaded update queued
  for the next attempt.

No silent fall-through.

`.detachFailed` (umount ok, dev node still attached) is *not* a
fatal precheck error — the kernel has already released the appex,
so the install can proceed.

## Plumbing

- `MountManager.unmountAndForget(_:) -> UnmountOutcome` extracted
  into `MountManager+Sweep.swift` and reused by both
  `ContentView.unmount` (existing per-row click) and the Sparkle
  delegate. Always calls `MountRegistry.forget` after umount
  succeeds, even on detach failure — the kernel no longer holds
  the volume so the registry must stop claiming it does.
- 60s outer budget on the precheck via a `Task.cancel`-driven
  watchdog. Per-mount waits are already bounded by ShellRunner's
  30s default; the watchdog stops a long mount list (or a wedged
  ShellRunner call) from outliving its budget.

## Verified

- `swift test`: 101 tests pass.
- `swiftlint --strict`: 0 violations across 36 files.
- `xcodebuild ... build`: succeeds, no new warnings.

## Out of scope

Manual drag-install (no in-process hook) — track separately. Could
detect stale state at next launch and offer cleanup.