### PR TITLE
First-launch sweep of stale LaunchServices registrations

### DIFF
--- a/TestFS/ContentView+Helpers.swift
+++ b/TestFS/ContentView+Helpers.swift
@@ -8,6 +8,7 @@
 //
 
 import AppKit
+import OSLog
 import SwiftUI
 
 /// App-wide constants shared between ContentView and AboutView.
@@ -49,25 +50,76 @@ enum AppEnvironment {
     /// A `false` return triggers `ExtensionReregistration` to clear
     /// its memoized task so a later mount click can retry instead
     /// of awaiting a wedged result forever.
+    /// Path to the private LaunchServices `lsregister` binary, used by
+    /// both `performReregisterIfNeeded` and `sweepStaleRegistrations`.
+    private static let lsregisterPath =
+        "/System/Library/Frameworks/CoreServices.framework"
+        + "/Versions/A/Frameworks/LaunchServices.framework"
+        + "/Versions/A/Support/lsregister"
+
     @discardableResult
     static func performReregisterIfNeeded() -> Bool {
+        // Sweep stale LaunchServices entries before any toggle work.
+        // macOS 26's ExtensionKit hard-fails (Cocoa 4099) when the
+        // bundle resolver latches onto a stale path that pluginkit
+        // no longer reflects, so accumulated DMG / Trash / dev-build
+        // registrations turn into "extensionKit error 2 / testfs not
+        // found" mount failures even with a clean install. See #68.
+        let sweptCount = sweepStaleRegistrations()
         let last = UserDefaults.standard.string(forKey: "verifiedMountedVersion") ?? ""
-        guard versionLabel != last else { return true }
+        // Toggle when the version changed (post-update) OR the sweep
+        // removed anything: extensionkitd may still have a UUID cached
+        // against a now-unregistered bundle, and only the ignore→use
+        // cycle drops that cache.
+        guard versionLabel != last || sweptCount > 0 else { return true }
 
         let appBundle = Bundle.main.bundleURL
         let appex = appBundle.appendingPathComponent(
             "Contents/Extensions/TestFSExtension.appex")
         guard FileManager.default.fileExists(atPath: appex.path) else { return false }
 
-        let lsregister = "/System/Library/Frameworks/CoreServices.framework"
-            + "/Versions/A/Frameworks/LaunchServices.framework"
-            + "/Versions/A/Support/lsregister"
         let bundleID = TestFSConstants.extensionBundleID
-        let ok1 = runSilently(lsregister, ["-f", appBundle.path])
+        let ok1 = runSilently(lsregisterPath, ["-f", appBundle.path])
         let ok2 = runSilently("/usr/bin/pluginkit", ["-a", appex.path])
         let ok3 = runSilently("/usr/bin/pluginkit", ["-e", "ignore", "-i", bundleID])
         let ok4 = runSilently("/usr/bin/pluginkit", ["-e", "use", "-i", bundleID])
         return ok1 && ok2 && ok3 && ok4
+    }
+
+    /// Sweep stale LaunchServices registrations for our host bundle
+    /// ID, keeping only the running bundle's path. `lsregister -u`
+    /// on an app bundle cascades to its embedded appex, so we don't
+    /// enumerate the extension's bundle ID separately.
+    ///
+    /// Returns the count of removed paths. Called every launch from
+    /// `performReregisterIfNeeded`; a non-zero return triggers the
+    /// extensionkitd toggle cycle even when the host version is
+    /// unchanged.
+    @discardableResult
+    static func sweepStaleRegistrations() -> Int {
+        let log = Logger(subsystem: TestFSConstants.logSubsystem, category: "lsregister-sweep")
+        guard let bundleID = Bundle.main.bundleIdentifier else { return 0 }
+        // Resolve symlinks: Gatekeeper translocation, /var ↔ /private/var,
+        // and bind-mount paths can otherwise produce false mismatches
+        // when comparing the same physical bundle.
+        let canonical = Bundle.main.bundleURL.resolvingSymlinksInPath().path
+        let stale = NSWorkspace.shared
+            .urlsForApplications(withBundleIdentifier: bundleID)
+            .filter { $0.resolvingSymlinksInPath().path != canonical }
+        guard !stale.isEmpty else { return 0 }
+        let stalePaths = stale.map(\.path)
+        for path in stalePaths {
+            log.info("sweeping stale registration: \(path, privacy: .public)")
+        }
+        // `lsregister -u` accepts N paths per invocation, so batch all
+        // stale removals into one subprocess to amortize fork+exec.
+        let batchOK = runSilently(lsregisterPath, ["-u"] + stalePaths)
+        if batchOK {
+            log.info("sweep removed \(stalePaths.count, privacy: .public) stale path(s)")
+            return stalePaths.count
+        }
+        log.error("sweep failed for batch of \(stalePaths.count, privacy: .public) path(s)")
+        return 0
     }
 
     /// 5s per command. Real `lsregister`/`pluginkit` runs finish in


### PR DESCRIPTION
Fixes #68.

End users hit `mount exit 69 / extensionKit error 2 / File system
named testfs not found` even on a clean 0.1.19 install. Diagnosed
on a remote 0.1.19 machine where:

- Bundle is well-formed (host + extension build 101, signed,
  notarized, entitled, gatekeeper accepts).
- pluginkit lists exactly one `+`-enabled appex pointing at the
  /Applications path.
- fskitd's `probeResource` succeeds.
- fskitd's `loadResource` fails at the extension-launch step:
  ```
  extensionKit.errorDomain Code=2
    UserInfo={NSUnderlyingError=NSCocoaErrorDomain Code=4099}
  ```
  Cocoa 4099 = `NSXPCConnectionInvalid`. extensionkitd refuses to
  launch the appex's XPC instance.

LaunchServices on the affected machine had 7 paths registered for
`com.sohonet.testfsmount` (Trash + 5 stale DMG mount points + the
real /Applications path). pluginkit reflects only the canonical
+enabled flag, but extensionkitd's UUID resolution can latch onto
a stale path. macOS 26's stricter ExtensionKit hard-fails this
case where earlier macOS versions silently coped.

## Fix

At first launch, sweep stale registrations before the existing
re-register flow. Wired into the existing
`AppEnvironment.performReregisterIfNeeded()` so it runs once per
process via `ExtensionReregistration`.

- `NSWorkspace.urlsForApplications(withBundleIdentifier:)` (macOS 12+)
  enumerates every registered URL for our host bundle ID — no
  shelling out for discovery.
- Each URL's `resolvingSymlinksInPath()` is compared against
  `Bundle.main.bundleURL.resolvingSymlinksInPath()` to handle
  Gatekeeper translocation, `/var ↔ /private/var`, and bind-mount
  variants without false mismatch.
- A single batched `lsregister -u <path1> <path2>...` removes every
  stale path in one subprocess (fork+exec amortized).
- `lsregister -u` cascades to embedded appex, so the extension's
  bundle ID isn't enumerated separately.

Run order in `performReregisterIfNeeded`:
1. Sweep — always.
2. If sweep removed anything OR host version changed: run the
   four-step toggle cycle (`lsregister -f` → `pluginkit -a` →
   `pluginkit -e ignore` → `pluginkit -e use`). The toggle drops
   extensionkitd's UUID cache; running it after the sweep ensures
   the cache is clean of any unregistered path.
3. Otherwise: skip the toggle.

Also extracts the `lsregister` path into a single
`AppEnvironment.lsregisterPath` constant, used by both
`performReregisterIfNeeded` and `sweepStaleRegistrations`.

## Verified

- `swift test`: 101 tests pass.
- `swiftlint --strict`: 0 violations across 36 files.
- `xcodebuild ... build`: succeeds.

No SPM-reachable test surface (host-only zone). Manual verification:
sweep activity logs under `com.sohonet.testfs:lsregister-sweep`
category in `log show`.

## Out of scope

- ShellRunner consolidation between `runSilently` and `ShellRunner.run`
  (already tracked).
- `release.sh` / `install.sh` build-time stale-bundle pruning — those
  use hard-coded glob lists for paths that aren't yet registered, so
  the runtime sweep here doesn't replace them.