### PR TITLE
Sweep dead-file lsregister entries; kill orphan extension processes

### DIFF
--- a/TestFS/AppEnvironment+ExtensionLifecycle.swift
+++ b/TestFS/AppEnvironment+ExtensionLifecycle.swift
@@ -27,19 +27,19 @@ extension AppEnvironment {
         guard result.exit == 0 else { return [] }
         var matches: [String] = []
         var pendingPath: String?
-        for rawLine in result.stdout.split(separator: "\n", omittingEmptySubsequences: false) {
-            let line = String(rawLine)
+        for line in result.stdout.split(separator: "\n", omittingEmptySubsequences: false) {
             if line.hasPrefix("path:") {
-                let trimmed = line.dropFirst("path:".count).trimmingCharacters(in: CharacterSet.whitespaces)
+                let trimmed = line.trimmingPrefix("path:")
+                    .trimmingCharacters(in: .whitespaces)
                 // Strip the trailing `(0xNNNN)` registration ID.
                 if let parenIdx = trimmed.lastIndex(of: "(") {
-                    pendingPath = trimmed[..<parenIdx].trimmingCharacters(in: CharacterSet.whitespaces)
+                    pendingPath = trimmed[..<parenIdx].trimmingCharacters(in: .whitespaces)
                 } else {
                     pendingPath = trimmed
                 }
             } else if line.hasPrefix("identifier:") {
-                let identifier = line.dropFirst("identifier:".count)
-                    .trimmingCharacters(in: CharacterSet.whitespaces)
+                let identifier = line.trimmingPrefix("identifier:")
+                    .trimmingCharacters(in: .whitespaces)
                 if identifier == bundleID, let path = pendingPath {
                     matches.append(path)
                 }
@@ -54,20 +54,14 @@ extension AppEnvironment {
     /// ExtensionKit instances; the pluginkit toggle alone doesn't
     /// always reap them either. extensionkitd then refuses to spawn
     /// a fresh instance for the new bundle and the user gets
-    /// `Cocoa 4099 / NSXPCConnectionInvalid`. SIGTERM to any process
-    /// running the extension binary forces a clean replacement on
-    /// the next mount. Returns 1 if pkill found and signalled at
-    /// least one process, 0 otherwise.
-    @discardableResult
+    /// `Cocoa 4099 / NSXPCConnectionInvalid`. Returns 1 if at least
+    /// one process was signalled, 0 otherwise.
     static func killOrphanExtensionProcesses() -> Int {
         let log = Logger(subsystem: TestFSConstants.logSubsystem, category: "orphan-kill")
         let extensionBinary = Bundle.main.bundleURL
             .appendingPathComponent("Contents/Extensions/TestFSExtension.appex")
             .appendingPathComponent("Contents/MacOS/TestFSExtension")
             .resolvingSymlinksInPath().path
-        // pkill -f matches the substring against the full command line
-        // (including the appex's `-LaunchArguments <base64>` payload).
-        // Exit 0 = at least one process signalled, 1 = no match.
         let result = ShellRunner.run("/usr/bin/pkill", ["-f", extensionBinary])
         if result.exit == 0 {
             log.info("killed orphan TestFSExtension process(es)")

--- a/TestFS/AppEnvironment+ExtensionLifecycle.swift
+++ b/TestFS/AppEnvironment+ExtensionLifecycle.swift
@@ -1,0 +1,78 @@
+//
+//  AppEnvironment+ExtensionLifecycle.swift
+//  TestFS
+//
+//  Lower-level helpers for the first-launch extension cleanup that
+//  `performReregisterIfNeeded` orchestrates: parsing `lsregister
+//  -dump` for stale registrations the macOS 12+ NSWorkspace API
+//  hides, and killing orphan extension processes left over after a
+//  Sparkle update. Pulled into its own file so the ContentView
+//  helpers stay within SwiftLint's file_length budget.
+//
+
+import Foundation
+import OSLog
+
+extension AppEnvironment {
+    /// Parse `lsregister -dump` for every path registered against the
+    /// given bundle identifier. The dump format pairs each registration
+    /// with `path:` followed by `identifier:` on consecutive lines.
+    /// Used in preference to `NSWorkspace.urlsForApplications` because
+    /// the latter filters out registrations whose underlying file no
+    /// longer exists (unmounted DMGs, deleted Trash items) — which
+    /// are exactly the entries most likely to confuse extensionkitd's
+    /// UUID resolution.
+    static func registeredPaths(forBundleID bundleID: String) -> [String] {
+        let result = ShellRunner.run(lsregisterPath, ["-dump"])
+        guard result.exit == 0 else { return [] }
+        var matches: [String] = []
+        var pendingPath: String?
+        for rawLine in result.stdout.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(rawLine)
+            if line.hasPrefix("path:") {
+                let trimmed = line.dropFirst("path:".count).trimmingCharacters(in: CharacterSet.whitespaces)
+                // Strip the trailing `(0xNNNN)` registration ID.
+                if let parenIdx = trimmed.lastIndex(of: "(") {
+                    pendingPath = trimmed[..<parenIdx].trimmingCharacters(in: CharacterSet.whitespaces)
+                } else {
+                    pendingPath = trimmed
+                }
+            } else if line.hasPrefix("identifier:") {
+                let identifier = line.dropFirst("identifier:".count)
+                    .trimmingCharacters(in: CharacterSet.whitespaces)
+                if identifier == bundleID, let path = pendingPath {
+                    matches.append(path)
+                }
+                pendingPath = nil
+            }
+        }
+        return matches
+    }
+
+    /// Kill any TestFSExtension process left over from a prior
+    /// version. Sparkle's bundle replace doesn't tear down live
+    /// ExtensionKit instances; the pluginkit toggle alone doesn't
+    /// always reap them either. extensionkitd then refuses to spawn
+    /// a fresh instance for the new bundle and the user gets
+    /// `Cocoa 4099 / NSXPCConnectionInvalid`. SIGTERM to any process
+    /// running the extension binary forces a clean replacement on
+    /// the next mount. Returns 1 if pkill found and signalled at
+    /// least one process, 0 otherwise.
+    @discardableResult
+    static func killOrphanExtensionProcesses() -> Int {
+        let log = Logger(subsystem: TestFSConstants.logSubsystem, category: "orphan-kill")
+        let extensionBinary = Bundle.main.bundleURL
+            .appendingPathComponent("Contents/Extensions/TestFSExtension.appex")
+            .appendingPathComponent("Contents/MacOS/TestFSExtension")
+            .resolvingSymlinksInPath().path
+        // pkill -f matches the substring against the full command line
+        // (including the appex's `-LaunchArguments <base64>` payload).
+        // Exit 0 = at least one process signalled, 1 = no match.
+        let result = ShellRunner.run("/usr/bin/pkill", ["-f", extensionBinary])
+        if result.exit == 0 {
+            log.info("killed orphan TestFSExtension process(es)")
+            return 1
+        }
+        return 0
+    }
+}

--- a/TestFS/ContentView+Helpers.swift
+++ b/TestFS/ContentView+Helpers.swift
@@ -52,7 +52,7 @@ enum AppEnvironment {
     /// of awaiting a wedged result forever.
     /// Path to the private LaunchServices `lsregister` binary, used by
     /// both `performReregisterIfNeeded` and `sweepStaleRegistrations`.
-    private static let lsregisterPath =
+    static let lsregisterPath =
         "/System/Library/Frameworks/CoreServices.framework"
         + "/Versions/A/Frameworks/LaunchServices.framework"
         + "/Versions/A/Support/lsregister"
@@ -66,12 +66,20 @@ enum AppEnvironment {
         // registrations turn into "extensionKit error 2 / testfs not
         // found" mount failures even with a clean install. See #68.
         let sweptCount = sweepStaleRegistrations()
+        // Kill any orphan TestFSExtension process from before the
+        // upgrade. Sparkle's bundle replace doesn't terminate live
+        // ExtensionKit instances, and pluginkit's toggle cycle can
+        // leave the old PID alive holding a stale UUID — extensionkitd
+        // then refuses to start a fresh instance with Cocoa 4099. See #70.
+        let orphansKilled = killOrphanExtensionProcesses()
         let last = UserDefaults.standard.string(forKey: "verifiedMountedVersion") ?? ""
-        // Toggle when the version changed (post-update) OR the sweep
-        // removed anything: extensionkitd may still have a UUID cached
-        // against a now-unregistered bundle, and only the ignore→use
-        // cycle drops that cache.
-        guard versionLabel != last || sweptCount > 0 else { return true }
+        // Toggle when the version changed (post-update), the sweep
+        // removed anything, or we just killed an orphan: extensionkitd
+        // may still have a UUID cached against the just-cleared state,
+        // and only the ignore→use cycle drops that cache.
+        guard versionLabel != last || sweptCount > 0 || orphansKilled > 0 else {
+            return true
+        }
 
         let appBundle = Bundle.main.bundleURL
         let appex = appBundle.appendingPathComponent(
@@ -87,32 +95,27 @@ enum AppEnvironment {
     }
 
     /// Sweep stale LaunchServices registrations for our host bundle
-    /// ID, keeping only the running bundle's path. `lsregister -u`
-    /// on an app bundle cascades to its embedded appex, so we don't
-    /// enumerate the extension's bundle ID separately.
-    ///
-    /// Returns the count of removed paths. Called every launch from
-    /// `performReregisterIfNeeded`; a non-zero return triggers the
-    /// extensionkitd toggle cycle even when the host version is
-    /// unchanged.
+    /// ID, keeping only the running bundle's path. Enumerates via
+    /// `lsregister -dump` parsing rather than `urlsForApplications`
+    /// because the latter filters out registrations whose underlying
+    /// file no longer exists (unmounted DMGs, deleted Trash items) —
+    /// which are exactly the entries most likely to confuse
+    /// extensionkitd's UUID resolution. `lsregister -u` on a host
+    /// bundle cascades to the embedded appex, so the extension's
+    /// bundle ID isn't enumerated separately.
     @discardableResult
     static func sweepStaleRegistrations() -> Int {
         let log = Logger(subsystem: TestFSConstants.logSubsystem, category: "lsregister-sweep")
         guard let bundleID = Bundle.main.bundleIdentifier else { return 0 }
-        // Resolve symlinks: Gatekeeper translocation, /var ↔ /private/var,
-        // and bind-mount paths can otherwise produce false mismatches
-        // when comparing the same physical bundle.
         let canonical = Bundle.main.bundleURL.resolvingSymlinksInPath().path
-        let stale = NSWorkspace.shared
-            .urlsForApplications(withBundleIdentifier: bundleID)
-            .filter { $0.resolvingSymlinksInPath().path != canonical }
-        guard !stale.isEmpty else { return 0 }
-        let stalePaths = stale.map(\.path)
+        let stalePaths = registeredPaths(forBundleID: bundleID)
+            .filter { URL(fileURLWithPath: $0).resolvingSymlinksInPath().path != canonical }
+        guard !stalePaths.isEmpty else { return 0 }
         for path in stalePaths {
             log.info("sweeping stale registration: \(path, privacy: .public)")
         }
-        // `lsregister -u` accepts N paths per invocation, so batch all
-        // stale removals into one subprocess to amortize fork+exec.
+        // `lsregister -u` accepts N paths per invocation; batching
+        // amortizes fork+exec across long stale lists.
         let batchOK = runSilently(lsregisterPath, ["-u"] + stalePaths)
         if batchOK {
             log.info("sweep removed \(stalePaths.count, privacy: .public) stale path(s)")

--- a/TestFS/ContentView+Helpers.swift
+++ b/TestFS/ContentView+Helpers.swift
@@ -59,27 +59,24 @@ enum AppEnvironment {
 
     @discardableResult
     static func performReregisterIfNeeded() -> Bool {
+        // Skip the whole cleanup path when we already verified a
+        // mount on this version. The dump+parse + pkill + four-step
+        // toggle is multi-MB read + several subprocesses; running it
+        // every launch on a stable install is wasted work. The stamp
+        // resets on every release, so post-upgrade always cleans up.
+        let last = UserDefaults.standard.string(forKey: "verifiedMountedVersion") ?? ""
+        guard versionLabel != last else { return true }
+
         // Sweep stale LaunchServices entries before any toggle work.
         // macOS 26's ExtensionKit hard-fails (Cocoa 4099) when the
         // bundle resolver latches onto a stale path that pluginkit
-        // no longer reflects, so accumulated DMG / Trash / dev-build
-        // registrations turn into "extensionKit error 2 / testfs not
-        // found" mount failures even with a clean install. See #68.
-        let sweptCount = sweepStaleRegistrations()
+        // no longer reflects (#68).
+        sweepStaleRegistrations()
         // Kill any orphan TestFSExtension process from before the
         // upgrade. Sparkle's bundle replace doesn't terminate live
-        // ExtensionKit instances, and pluginkit's toggle cycle can
-        // leave the old PID alive holding a stale UUID — extensionkitd
-        // then refuses to start a fresh instance with Cocoa 4099. See #70.
-        let orphansKilled = killOrphanExtensionProcesses()
-        let last = UserDefaults.standard.string(forKey: "verifiedMountedVersion") ?? ""
-        // Toggle when the version changed (post-update), the sweep
-        // removed anything, or we just killed an orphan: extensionkitd
-        // may still have a UUID cached against the just-cleared state,
-        // and only the ignore→use cycle drops that cache.
-        guard versionLabel != last || sweptCount > 0 || orphansKilled > 0 else {
-            return true
-        }
+        // ExtensionKit instances, leaving the old PID alive holding a
+        // stale UUID (#70).
+        _ = killOrphanExtensionProcesses()
 
         let appBundle = Bundle.main.bundleURL
         let appex = appBundle.appendingPathComponent(


### PR DESCRIPTION
Fixes #70.

PR #69 (#68) made first launch sweep stale LaunchServices
registrations, but used `NSWorkspace.urlsForApplications(
withBundleIdentifier:)` for enumeration. That API filters out
URLs whose underlying file is gone — LaunchServices keeps the
registration anyway. On the affected machine we swept 1 of 6
stale paths and mount still failed with `extensionKit error 2 /
Cocoa 4099`.

## Fix

1. **lsregister -dump parsing** replaces the `urlsForApplications`
   enumeration. The dump format pairs each registration's `path:`
   with the following `identifier:` line — a stateful scan
   collects paths whose identifier matches our host bundle ID,
   regardless of whether the file still exists.
2. **Kill orphan TestFSExtension processes** during the reregister
   cycle. `pkill -f <ext-binary>` against the resolved appex binary
   path. Sparkle's bundle replace + pluginkit toggle don't reap
   these — extensionkitd then refuses to spawn a fresh instance.

Order in `performReregisterIfNeeded`:
1. Sweep — always.
2. Orphan kill — always.
3. Toggle cycle when host version changed OR sweep removed
   anything OR orphan was killed.

`registeredPaths` + `killOrphanExtensionProcesses` extracted to a
new `AppEnvironment+ExtensionLifecycle.swift` to keep
`ContentView+Helpers.swift` under the file-length budget.
`lsregisterPath` promoted from private to internal for cross-file
share.

## Verified

- `swift test`: 101 tests pass.
- `swiftlint --strict`: 0 violations across 37 files.
- `xcodebuild ... build`: succeeds.

No SPM-reachable test surface (host-only zone, helpers target
system tools).