### PR TITLE
Reregister cleanup: kill fskit_agent to flush stale XPC cache

### DIFF
--- a/TestFS/AppEnvironment+ExtensionLifecycle.swift
+++ b/TestFS/AppEnvironment+ExtensionLifecycle.swift
@@ -54,9 +54,8 @@ extension AppEnvironment {
     /// ExtensionKit instances; the pluginkit toggle alone doesn't
     /// always reap them either. extensionkitd then refuses to spawn
     /// a fresh instance for the new bundle and the user gets
-    /// `Cocoa 4099 / NSXPCConnectionInvalid`. Returns 1 if at least
-    /// one process was signalled, 0 otherwise.
-    static func killOrphanExtensionProcesses() -> Int {
+    /// `Cocoa 4099 / NSXPCConnectionInvalid`.
+    static func killOrphanExtensionProcesses() {
         let log = Logger(subsystem: TestFSConstants.logSubsystem, category: "orphan-kill")
         let extensionBinary = Bundle.main.bundleURL
             .appendingPathComponent("Contents/Extensions/TestFSExtension.appex")
@@ -65,9 +64,7 @@ extension AppEnvironment {
         let result = ShellRunner.run("/usr/bin/pkill", ["-f", extensionBinary])
         if result.exit == 0 {
             log.info("killed orphan TestFSExtension process(es)")
-            return 1
         }
-        return 0
     }
 
     /// Kill `fskit_agent`, the per-user FSKit broker. It holds an
@@ -78,14 +75,12 @@ extension AppEnvironment {
     /// "connection to service with pid <N> was invalidated"`.
     /// `fskit_agent` is a launchd user service
     /// (`com.apple.fskit.fskit_agent`); kicking it forces fresh XPC
-    /// state on next demand. Returns 1 if a process was signalled.
-    static func killFSKitAgent() -> Int {
+    /// state on next demand.
+    static func killFSKitAgent() {
         let log = Logger(subsystem: TestFSConstants.logSubsystem, category: "fskit-agent-kill")
         let result = ShellRunner.run("/usr/bin/pkill", ["-x", "fskit_agent"])
         if result.exit == 0 {
             log.info("killed fskit_agent to flush per-user XPC cache")
-            return 1
         }
-        return 0
     }
 }

--- a/TestFS/AppEnvironment+ExtensionLifecycle.swift
+++ b/TestFS/AppEnvironment+ExtensionLifecycle.swift
@@ -69,4 +69,23 @@ extension AppEnvironment {
         }
         return 0
     }
+
+    /// Kill `fskit_agent`, the per-user FSKit broker. It holds an
+    /// in-memory cache of XPC connections to sibling helpers; when
+    /// we kill an orphan appex, sibling helpers can be torn down by
+    /// runningboard but the broker's cache still references their
+    /// PIDs. Subsequent spawn attempts then fail with `Cocoa 4099 /
+    /// "connection to service with pid <N> was invalidated"`.
+    /// `fskit_agent` is a launchd user service
+    /// (`com.apple.fskit.fskit_agent`); kicking it forces fresh XPC
+    /// state on next demand. Returns 1 if a process was signalled.
+    static func killFSKitAgent() -> Int {
+        let log = Logger(subsystem: TestFSConstants.logSubsystem, category: "fskit-agent-kill")
+        let result = ShellRunner.run("/usr/bin/pkill", ["-x", "fskit_agent"])
+        if result.exit == 0 {
+            log.info("killed fskit_agent to flush per-user XPC cache")
+            return 1
+        }
+        return 0
+    }
 }

--- a/TestFS/ContentView+Helpers.swift
+++ b/TestFS/ContentView+Helpers.swift
@@ -77,6 +77,13 @@ enum AppEnvironment {
         // ExtensionKit instances, leaving the old PID alive holding a
         // stale UUID (#70).
         _ = killOrphanExtensionProcesses()
+        // Kill fskit_agent's stale XPC cache. Killing an orphan appex
+        // tears down sibling helpers via runningboard; fskit_agent
+        // (the per-user broker) still references those torn-down
+        // PIDs and every subsequent spawn fails with `connection to
+        // service with pid <N> was invalidated`. launchd respawns it
+        // on demand (#72).
+        _ = killFSKitAgent()
 
         let appBundle = Bundle.main.bundleURL
         let appex = appBundle.appendingPathComponent(

--- a/TestFS/ContentView+Helpers.swift
+++ b/TestFS/ContentView+Helpers.swift
@@ -76,14 +76,14 @@ enum AppEnvironment {
         // upgrade. Sparkle's bundle replace doesn't terminate live
         // ExtensionKit instances, leaving the old PID alive holding a
         // stale UUID (#70).
-        _ = killOrphanExtensionProcesses()
+        killOrphanExtensionProcesses()
         // Kill fskit_agent's stale XPC cache. Killing an orphan appex
         // tears down sibling helpers via runningboard; fskit_agent
         // (the per-user broker) still references those torn-down
         // PIDs and every subsequent spawn fails with `connection to
         // service with pid <N> was invalidated`. launchd respawns it
         // on demand (#72).
-        _ = killFSKitAgent()
+        killFSKitAgent()
 
         let appBundle = Bundle.main.bundleURL
         let appex = appBundle.appendingPathComponent(


### PR DESCRIPTION
Fixes #72.

0.1.21's sweep + orphan-kill correctly removed every stale
`lsregister` entry and the orphan `TestFSExtension` process — but
mount still failed with `extensionKit error 2 / Cocoa 4099` on
the affected machine. fskit_agent log:

```
fskit_agent[930] Failed to create extensionProcess for extension
'com.sohonet.testfsmount.appex' error: ... "The connection to
service with pid 2467 named (null) was invalidated."
```

PID 2467 was a sibling helper that runningboard tore down when we
killed the orphan appex. `fskit_agent` (the long-running per-user
FSKit broker) holds an in-memory cache of XPC connections; that
cache still referenced the torn-down PID. Every spawn attempt
routed through the stale cache and failed.

## Fix

Add `pkill -x fskit_agent` to the cleanup chain in
`AppEnvironment+ExtensionLifecycle.swift`. `fskit_agent` is a
launchd user service (`com.apple.fskit.fskit_agent`) — auto-respawns
on demand, no harm done.

Order in `performReregisterIfNeeded`:
1. `sweepStaleRegistrations` — clear LS database (#68 / #70).
2. `killOrphanExtensionProcesses` — clear live appex PID (#70).
3. **`killFSKitAgent`** — clear per-user XPC cache (this PR).
4. `lsregister -f` / pluginkit toggle — re-adjudicate.

Together (1-3) plus toggle: every layer of cached state that could
reference the previous bundle's UUIDs is forced to re-init.

## Simplify pass

- Dropped dead `-> Int` returns on both kill helpers; callers
  discard. `Void` is the honest signature.

## Verified

- `swift test`: 101 tests pass.
- `swiftlint --strict`: 0 violations across 37 files.
- `xcodebuild ... build`: succeeds.

Manual verification will follow on the affected machine post-update.